### PR TITLE
44: Write activities containing a failure in red

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ DerivedData/
 *.perspectivev3
 !default.perspectivev3
 xcuserdata/
+xchtmlreport.swiftmodule/
 
 ## Other
 *.moved-aside

--- a/XCTestHTMLReport/XCTestHTMLReport.xcodeproj/project.pbxproj
+++ b/XCTestHTMLReport/XCTestHTMLReport.xcodeproj/project.pbxproj
@@ -65,7 +65,7 @@
 		F30667501F2A1BB900EDE682 /* StringGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringGenerator.swift; sourceTree = "<group>"; };
 		F30667511F2A1BB900EDE682 /* Style.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Style.swift; sourceTree = "<group>"; };
 		F30667521F2A1BB900EDE682 /* XcodeColorsSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodeColorsSupport.swift; sourceTree = "<group>"; };
-		F324B4951F22359500B5B8B4 /* XCTestHTMLReport */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = XCTestHTMLReport; sourceTree = BUILT_PRODUCTS_DIR; };
+		F324B4951F22359500B5B8B4 /* xchtmlreport */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = xchtmlreport; sourceTree = BUILT_PRODUCTS_DIR; };
 		F324B4981F22359500B5B8B4 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		F324B49F1F22383D00B5B8B4 /* Argument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Argument.swift; sourceTree = "<group>"; };
 		F340F8171F2A37B000AECEE2 /* TimeInterval+Time.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+Time.swift"; sourceTree = "<group>"; };
@@ -128,7 +128,7 @@
 		F324B4961F22359500B5B8B4 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				F324B4951F22359500B5B8B4 /* XCTestHTMLReport */,
+				F324B4951F22359500B5B8B4 /* xchtmlreport */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -223,7 +223,7 @@
 			);
 			name = XCTestHTMLReport;
 			productName = XCTestHTMLReport;
-			productReference = F324B4951F22359500B5B8B4 /* XCTestHTMLReport */;
+			productReference = F324B4951F22359500B5B8B4 /* xchtmlreport */;
 			productType = "com.apple.product-type.tool";
 		};
 /* End PBXNativeTarget section */
@@ -425,14 +425,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/builds";
+				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/..";
 				DEVELOPMENT_TEAM = XK98WVAH5W;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = xchtmlreport;
 				SWIFT_OBJC_BRIDGING_HEADER = "XCTestHTMLReport/Libraries/XCTestHTMLReport-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.0;
-				SYMROOT = "$(SRCROOT)/builds";
+				SYMROOT = "$(SRCROOT)/..";
 			};
 			name = Debug;
 		};
@@ -440,13 +440,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/builds";
+				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/..";
 				DEVELOPMENT_TEAM = XK98WVAH5W;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = xchtmlreport;
 				SWIFT_OBJC_BRIDGING_HEADER = "XCTestHTMLReport/Libraries/XCTestHTMLReport-Bridging-Header.h";
 				SWIFT_VERSION = 4.0;
-				SYMROOT = "$(SRCROOT)/builds";
+				SYMROOT = "$(SRCROOT)/..";
 			};
 			name = Release;
 		};

--- a/XCTestHTMLReport/XCTestHTMLReport.xcodeproj/xcshareddata/xcschemes/XCTestHTMLReport.xcscheme
+++ b/XCTestHTMLReport/XCTestHTMLReport.xcodeproj/xcshareddata/xcschemes/XCTestHTMLReport.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0920"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -10,12 +10,12 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "cp $SRCROOT/builds/XCTestHTMLReport $SRCROOT/../xchtmlreport&#10;chmod 755 $SRCROOT/../xchtmlreport">
+               scriptText = "cp $SRCROOT/../xchtmlreport /usr/local/bin/">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
                      BlueprintIdentifier = "F324B4941F22359500B5B8B4"
-                     BuildableName = "XCTestHTMLReport"
+                     BuildableName = "xchtmlreport"
                      BlueprintName = "XCTestHTMLReport"
                      ReferencedContainer = "container:XCTestHTMLReport.xcodeproj">
                   </BuildableReference>
@@ -83,12 +83,8 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "-r ../../TestResults -v"
+            argument = "-r ../../TestResults"
             isEnabled = "YES">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "-h"
-            isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>
       <AdditionalOptions>

--- a/XCTestHTMLReport/XCTestHTMLReport/Models/Activity.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Models/Activity.swift
@@ -54,6 +54,21 @@ struct Activity: HTML
         let subActivitesHaveAttachments = subActivities?.reduce(false) { $0 || $1.hasGlobalAttachment } ?? false
         return hasDirecAttachment || subActivitesHaveAttachments
     }
+    var hasFailingSubActivities: Bool {
+        return subActivities?.reduce(false) { $0 || $1.type == .assertionFailure } ?? false
+    }
+    var cssClasses: String {
+        var cls = ""
+        if let type = type {
+            cls += type.cssClass
+
+            if type == .userCreated && hasFailingSubActivities {
+                cls += " activity-assertion-failure"
+            }
+        }
+
+        return cls
+    }
     
     init(root: String, dict: [String : Any], padding: Int) {
         uuid = dict["UUID"] as! String
@@ -90,7 +105,7 @@ struct Activity: HTML
             "PAPER_CLIP_CLASS": hasGlobalAttachment ? "inline-block" : "none",
             "PADDING": (subActivities == nil && (attachments == nil || attachments?.count == 0)) ? String(padding + 18) : String(padding),
             "TIME": totalTime.timeString,
-            "ACTIVITY_TYPE_CLASS": type?.cssClass ?? "",
+            "ACTIVITY_TYPE_CLASS": cssClasses,
             "HAS_SUB-ACTIVITIES_CLASS": (subActivities == nil && (attachments == nil || attachments?.count == 0)) ? "no-drop-down" : "",
             "SUB_ACTIVITY": subActivities?.reduce("", { (accumulator: String, activity: Activity) -> String in
                 return accumulator + activity.html

--- a/XCTestHTMLReportSampleApp/XCTestHTMLReportSampleApp.xcodeproj/xcshareddata/xcschemes/XCTestHTMLReportSampleApp.xcscheme
+++ b/XCTestHTMLReportSampleApp/XCTestHTMLReportSampleApp.xcodeproj/xcshareddata/xcschemes/XCTestHTMLReportSampleApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
#44 

If the code making the test fail is contained in an activity then the PR will write the activity in red
so that it's easier to find which activity is failing especially in case continueAfterFailure = true

**Screenshot**
<img width="476" alt="screen shot 2018-02-08 at 21 13 41" src="https://user-images.githubusercontent.com/1162441/35996016-856bc54c-0d15-11e8-828e-0b0a3902ddd2.png">
