### PR TITLE
56: failed to extract activity logs

### DIFF
--- a/XCTestHTMLReport/XCTestHTMLReport/Models/Run.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Models/Run.swift
@@ -79,10 +79,10 @@ struct Run: HTML
             let logs = String(data: gunzippedData, encoding: .utf8)!
 
             Logger.substep("Extracting useful activity logs")
-            let runningTestsPattern = "Running tests..."
+            let runningTestsPattern = "Test Suite '.+' started at"
             let runningTestsRegex = try! NSRegularExpression(pattern: runningTestsPattern, options: .caseInsensitive)
             let runningTestsMatches = runningTestsRegex.matches(in: logs, options: [], range: NSRange(location: 0, length: logs.count))
-            let lastRunningTestsMatch = runningTestsMatches.last
+            let lastRunningTestsMatch = runningTestsMatches.first
 
             guard lastRunningTestsMatch != nil else {
                 Logger.warning("Failed to extract activity logs. Could not locate match for \"\(runningTestsPattern)\" ")


### PR DESCRIPTION
⚠️ Not ready to be merged

Fixes #56 

TODO:

- [x] Test on Xcode 9.3.x
- [x] Test on Xcode 9.2.x
- [x] Test on Xcode 9.1.x
- [x] Test on Xcode 9.0.x
- [x] Test on Xcode 8.3.x