### PR TITLE
Add log to print summary test result

### DIFF
--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Summary.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Summary.swift
@@ -13,6 +13,10 @@ struct Summary
     private let filename = "action_TestSummaries.plist"
 
     var runs = [Run]()
+    
+    var totalNumberOfPassedTests = 0
+    var totalNumberOfFailedTests = 0
+    var totalNumberOfTests = 0
 
     init(roots: [String])
     {
@@ -38,8 +42,16 @@ struct Summary
             for path in plistPath {
                 let run = Run(root: root, path: path)
                 runs.append(run)
+                totalNumberOfPassedTests += run.numberOfPassedTests
+                totalNumberOfFailedTests += run.numberOfFailedTests
+                totalNumberOfTests += run.numberOfTests
             }
         }
+        
+        Logger.step("Summary result")
+        Logger.substep("Total number of tests: \(totalNumberOfTests)")
+        Logger.substep("Total number of passed tests: \(totalNumberOfPassedTests)")
+        Logger.substep("Total number of failed tests: \(totalNumberOfFailedTests)")
     }
 }
 


### PR DESCRIPTION
**Purpose**: 
I run XCTest using Jenkins with multiple result bundles. 
I would like to get some information about summary test to mark Jenkins build FAILED or SUCCESS
I added more verbose log to print some summary information, so that Jenkins can use this information for processing.