### PR TITLE
Fixed #84 : Updated CSS Styling to display the path to the assertion failure

### DIFF
--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/HTMLTemplates.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/HTMLTemplates.swift
@@ -364,7 +364,6 @@ struct HTMLTemplates
     }
 
     .test-summary p, .test-summary-group p, .activity p {
-      color: #111;
       font-size: 12px;
       padding: 4px 4px 4px 52px;
       border-bottom: 1px solid #EEE;
@@ -502,6 +501,14 @@ struct HTMLTemplates
       border: 0;
       width: 100%;
       flex: 1;
+    }
+
+    .list-item {
+      color: #111;
+    }
+
+    .list-item-failed {
+      color: red;
     }
 
     .list-item.selected {

--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Activity.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Activity.swift
@@ -55,7 +55,9 @@ struct Activity: HTML
         return hasDirecAttachment || subActivitesHaveAttachments
     }
     var hasFailingSubActivities: Bool {
-        return subActivities?.reduce(false) { $0 || $1.type == .assertionFailure } ?? false
+		guard let subActivities = subActivities else { return false }
+
+		return subActivities.reduce(false) { $0 || $1.type == .assertionFailure || $1.hasFailingSubActivities }
     }
     var cssClasses: String {
         var cls = ""

--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Test.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Test.swift
@@ -118,7 +118,7 @@ struct Test: HTML
             }) ?? "",
             "ICON_CLASS": status.cssClass,
             "ITEM_CLASS": objectClass.cssClass,
-            "LIST_ITEM_CLASS": objectClass == .testSummary ? "list-item" : ""
+			"LIST_ITEM_CLASS": objectClass == .testSummary ? (status == .failure ? "list-item-failed" : "list-item") : ""
         ]
     }
 }

--- a/XCTestHTMLReport/XCTestHTMLReport/HTML/index.html
+++ b/XCTestHTMLReport/XCTestHTMLReport/HTML/index.html
@@ -358,7 +358,6 @@
     }
 
     .test-summary p, .test-summary-group p, .activity p {
-      color: #111;
       font-size: 12px;
       padding: 4px 4px 4px 52px;
       border-bottom: 1px solid #EEE;
@@ -496,6 +495,14 @@
       border: 0;
       width: 100%;
       flex: 1;
+    }
+
+    .list-item {
+      color: #111;
+    }
+
+    .list-item-failed {
+      color: red;
     }
 
     .list-item.selected {

--- a/XCTestHTMLReportSampleApp/XCTestHTMLReportSampleApp.xcodeproj/project.pbxproj
+++ b/XCTestHTMLReportSampleApp/XCTestHTMLReportSampleApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		77239F5820CFAD7000BAB94E /* ThirdSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77239F5720CFAD7000BAB94E /* ThirdSuite.swift */; };
 		F39729081F2471A7006B1EF3 /* SecondSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = F39729071F2471A7006B1EF3 /* SecondSuite.swift */; };
 		F3AB012C1F2459FA00334580 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3AB012B1F2459FA00334580 /* AppDelegate.swift */; };
 		F3AB012E1F2459FA00334580 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3AB012D1F2459FA00334580 /* ViewController.swift */; };
@@ -36,6 +37,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		77239F5720CFAD7000BAB94E /* ThirdSuite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThirdSuite.swift; sourceTree = "<group>"; };
 		F3223CEF1F26341D00BEDA4A /* iPhone.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = iPhone.png; sourceTree = "<group>"; };
 		F39729071F2471A7006B1EF3 /* SecondSuite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondSuite.swift; sourceTree = "<group>"; };
 		F3AB01281F2459FA00334580 /* XCTestHTMLReportSampleApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = XCTestHTMLReportSampleApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -117,6 +119,7 @@
 				F3223CEF1F26341D00BEDA4A /* iPhone.png */,
 				F3AB01401F2459FA00334580 /* FirstSuite.swift */,
 				F39729071F2471A7006B1EF3 /* SecondSuite.swift */,
+				77239F5720CFAD7000BAB94E /* ThirdSuite.swift */,
 				F3AB01421F2459FA00334580 /* Info.plist */,
 			);
 			path = XCTestHTMLReportSampleAppUITests;
@@ -274,6 +277,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F39729081F2471A7006B1EF3 /* SecondSuite.swift in Sources */,
+				77239F5820CFAD7000BAB94E /* ThirdSuite.swift in Sources */,
 				F3AB01411F2459FA00334580 /* FirstSuite.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/XCTestHTMLReportSampleApp/XCTestHTMLReportSampleAppUITests/ThirdSuite.swift
+++ b/XCTestHTMLReportSampleApp/XCTestHTMLReportSampleAppUITests/ThirdSuite.swift
@@ -1,0 +1,47 @@
+//
+//  ThirdSuite.swift
+//  XCTestHTMLReportSampleAppUITests
+//
+//  Created by Fabien Lydoire on 12/06/18.
+//  Copyright © 2018 Fabien Lydoire. All rights reserved.
+//
+
+import XCTest
+
+class ThirdSuite: XCTestCase {
+
+	override func setUp() {
+		super.setUp()
+
+		// Put setup code here. This method is called before the invocation of each test method in the class.
+
+		// In UI tests it is usually best to stop immediately when a failure occurs.
+		continueAfterFailure = true
+		// UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
+		XCUIApplication().launch()
+	}
+
+	func testOne() {
+		XCTContext.runActivity(named: "test Activity - Success") { _ in
+			XCTAssert(true, "Test succeeded")
+		}
+		XCTContext.runActivity(named: "test Activity - Failure") { _ in
+			XCTAssert(false, "Test failed")
+		}
+		XCTContext.runActivity(named: "test Activity with sub-activities") { _ in
+			XCTContext.runActivity(named: "test sub Activity 0 - Failure") { _ in
+				XCTAssert(false, "Test failed")
+			}
+			XCTContext.runActivity(named: "test sub Activity 1 - Success") { _ in
+				XCTAssert(true, "Test succeeded")
+			}
+		}
+		XCTAssert(false, "Test failed")
+		XCTAssert(true, "Test succeeded")
+	}
+
+	func testTwo() {
+		let result = randomBool()
+		XCTAssert(result, "Test \(result ? "succeeded" : "failed")")
+	}
+}


### PR DESCRIPTION
Updated CSS Styling to display the path to the assertion failure in Red color.
Fixed a bug in Activity.hasFailingSubActivities being wrong with nested sub-activities.
Added a new ThirdSuite test to produce report with nested Activities.