### PR TITLE
Display attachment name if available

### DIFF
--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/HTMLTemplates.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/HTMLTemplates.swift
@@ -949,7 +949,7 @@ struct HTMLTemplates
   static let screenshot = """
   <p class=\"attachment list-item\">
     <span class=\"icon left screenshot-icon\" style=\"margin-left: [[PADDING]]px\"></span>
-    Screenshot
+    [[NAME]]
     <span class=\"icon preview-icon\" data=\"[[FILENAME]]\" onclick=\"showScreenshot('[[FILENAME]]')\"></span>
     <img class=\"screenshot\" src=\"[[PATH]]/Attachments/[[FILENAME]]\" id=\"screenshot-[[FILENAME]]\"/>
   </p>
@@ -958,7 +958,7 @@ struct HTMLTemplates
   static let text = """
   <p class=\"attachment list-item\">
     <span class=\"icon left text-icon\" style=\"margin-left: [[PADDING]]px\"></span>
-    Text
+    [[NAME]]
     <span class=\"icon preview-icon\" data=\"[[PATH]]/Attachments/[[FILENAME]]\" onclick=\"showText('[[PATH]]/Attachments/[[FILENAME]]')\"></span>
   </p>
   """

--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Attachment.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Attachment.swift
@@ -48,6 +48,7 @@ enum AttachmentName: RawRepresentable {
     init(rawValue: String) {
         if let constant = Constant(rawValue: rawValue) {
             self = .constant(constant)
+            return
         }
         
         self = .custom(rawValue)

--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Attachment.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Attachment.swift
@@ -28,12 +28,39 @@ enum AttachmentType: String {
     }
 }
 
+enum Name: RawRepresentable {
+    enum Constant: String {
+        case kXCTAttachmentLegacyScreenImageData = "kXCTAttachmentLegacyScreenImageData"
+    }
+    
+    case constant(Constant)
+    case custom(String)
+    
+    var rawValue: String {
+        switch self {
+        case .constant(let constant):
+            return constant.rawValue
+        case .custom(let rawValue):
+            return rawValue
+        }
+    }
+    
+    init(rawValue: String) {
+        if let constant = Constant(rawValue: rawValue) {
+            self = .constant(constant)
+        }
+        
+        self = .custom(rawValue)
+    }
+}
+
 struct Attachment: HTML
 {
     var padding = 0
     var filename: String
     var path: String
     var type: AttachmentType?
+    var name: Name?
 
     init(screenshotsPath: String, dict: [String : Any], padding: Int)
     {
@@ -46,10 +73,36 @@ struct Attachment: HTML
         } else {
             Logger.warning("Attachment type is not supported: \(typeRaw). Skipping.")
         }
+        
+        if let name = dict["Name"] as? String {
+            self.name = Name(rawValue: name)
+        }
 
         self.padding = padding
     }
 
+    var fallbackDisplayName: String {
+        guard let type = type else { return "Attachment" }
+        
+        switch type {
+        case .png, .jpeg:
+            return "Screenshot"
+        case .text, .html, .data:
+            return "File"
+        case .unknwown:
+            return "Attachment"
+        }
+    }
+    
+    var displayName: String {
+        switch name {
+        case .some(.custom(let customName)):
+            return customName
+        default:
+            return fallbackDisplayName
+        }
+    }
+    
     // PRAGMA MARK: - HTML
 
     var htmlTemplate: String {
@@ -71,7 +124,8 @@ struct Attachment: HTML
         return [
             "PADDING": String(padding),
             "PATH": path,
-            "FILENAME": filename
+            "FILENAME": filename,
+            "NAME": displayName
         ]
     }
 }

--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Attachment.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Attachment.swift
@@ -46,12 +46,12 @@ enum AttachmentName: RawRepresentable {
     }
     
     init(rawValue: String) {
-        if let constant = Constant(rawValue: rawValue) {
-            self = .constant(constant)
+        guard let constant = Constant(rawValue: rawValue) else {
+            self = .custom(rawValue)
             return
         }
         
-        self = .custom(rawValue)
+        self = .constant(constant)
     }
 }
 

--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Attachment.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Attachment.swift
@@ -28,7 +28,7 @@ enum AttachmentType: String {
     }
 }
 
-enum Name: RawRepresentable {
+enum AttachmentName: RawRepresentable {
     enum Constant: String {
         case kXCTAttachmentLegacyScreenImageData = "kXCTAttachmentLegacyScreenImageData"
     }
@@ -60,7 +60,7 @@ struct Attachment: HTML
     var filename: String
     var path: String
     var type: AttachmentType?
-    var name: Name?
+    var name: AttachmentName?
 
     init(screenshotsPath: String, dict: [String : Any], padding: Int)
     {
@@ -75,7 +75,7 @@ struct Attachment: HTML
         }
         
         if let name = dict["Name"] as? String {
-            self.name = Name(rawValue: name)
+            self.name = AttachmentName(rawValue: name)
         }
 
         self.padding = padding

--- a/XCTestHTMLReport/XCTestHTMLReport/HTML/screenshot.html
+++ b/XCTestHTMLReport/XCTestHTMLReport/HTML/screenshot.html
@@ -1,6 +1,6 @@
   <p class="attachment list-item">
     <span class="icon left screenshot-icon" style="margin-left: [[PADDING]]px"></span>
-    Screenshot
+    [[NAME]]
     <span class="icon preview-icon" data="[[FILENAME]]" onclick="showScreenshot('[[FILENAME]]')"></span>
     <img class="screenshot" src="[[PATH]]/Attachments/[[FILENAME]]" id="screenshot-[[FILENAME]]"/>
   </p>

--- a/XCTestHTMLReport/XCTestHTMLReport/HTML/text.html
+++ b/XCTestHTMLReport/XCTestHTMLReport/HTML/text.html
@@ -1,5 +1,5 @@
   <p class="attachment list-item">
     <span class="icon left text-icon" style="margin-left: [[PADDING]]px"></span>
-    Text
+    [[NAME]]
     <span class="icon preview-icon" data="[[PATH]]/Attachments/[[FILENAME]]" onclick="showText('[[PATH]]/Attachments/[[FILENAME]]')"></span>
   </p>


### PR DESCRIPTION
https://github.com/TitouanVanBelle/XCTestHTMLReport/issues/109

Displays the name of an attachment if user have provided such. One caveat is that I haven't tested with more than screenshots so `Name.Constants` is probably missing some values 🙂 

Before
![screenshot 2018-10-23 at 16 43 34](https://user-images.githubusercontent.com/650559/47369015-0d11f100-d6e3-11e8-8ca4-c5fe39899d51.png)

After
![screenshot 2018-10-23 at 16 44 57](https://user-images.githubusercontent.com/650559/47369023-11d6a500-d6e3-11e8-8056-f162937377d2.png)
