### PR TITLE
Point Homebrew formula's `head` to develop branch

### DIFF
--- a/xchtmlreport.rb
+++ b/xchtmlreport.rb
@@ -3,7 +3,7 @@ class Xchtmlreport < Formula
   homepage "https://github.com/TitouanVanBelle/XCTestHTMLReport"
   url "https://github.com/TitouanVanBelle/XCTestHTMLReport/archive/1.6.1.tar.gz"
   sha256 "6e0e3c30331bb32bbf38ebd438c1ee3a168432c10ece0f0292c7fdbb72483e0c"
-  head "https://github.com/TitouanVanBelle/XCTestHTMLReport.git"
+  head "https://github.com/TitouanVanBelle/XCTestHTMLReport.git", :branch => "develop"
 
   def install
     system "xcodebuild clean build CODE_SIGN_IDENTITY=\"\" CODE_SIGNING_REQUIRED=NO -workspace XCTestHTMLReport.xcworkspace -scheme XCTestHTMLReport -configuration Release"


### PR DESCRIPTION
Since the main development branch is apparently develop, we should update the `head` in the Homebrew spec to point to it, as it points to master by default.