### PR TITLE
Ensure log filename matches generated HTML

### DIFF
--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Run.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Run.swift
@@ -124,7 +124,7 @@ struct Run: HTML
             let activityLogs = logs[start..<end]
 
             do {
-                let file = "\(result.values.first!)/logs-\(runDestination.targetDevice.identifier).txt"
+                let file = "\(result.values.first!)/logs-\(runDestination.targetDevice.uniqueIdentifier).txt"
                 try activityLogs.write(toFile: file, atomically: false, encoding: .utf8)
             }
             catch let e {


### PR DESCRIPTION
Logs aren't working in develop. It seems the log file name doesn't match what the html points to.

Use the device's `uniqueIdentifier` instead of `identifier` in the file name of the logs txt file as this is what the HTML looks for. This seems to match the intent of the `uniqueIdentifier` property.

It could be the other way round though. Let me know if it should be and I can update.