### PR TITLE
Adding screenshot flow for the start of each test

### DIFF
--- a/XCTestHTMLReport/XCTestHTMLReport.xcodeproj/project.pbxproj
+++ b/XCTestHTMLReport/XCTestHTMLReport.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4C70D369219747FD0003015D /* TestScreenshotFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C70D368219747FD0003015D /* TestScreenshotFlow.swift */; };
 		B12D2AA11FC69B0700DE78C6 /* NSData+GZIP.m in Sources */ = {isa = PBXBuildFile; fileRef = B12D2AA01FC69B0700DE78C6 /* NSData+GZIP.m */; };
 		B12D2AA31FCB257500DE78C6 /* String+Path.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12D2AA21FCB257500DE78C6 /* String+Path.swift */; };
 		D980EDD4209123E400CABFE7 /* JUnitReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D980EDD3209123DB00CABFE7 /* JUnitReport.swift */; };
@@ -53,6 +54,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		4C70D368219747FD0003015D /* TestScreenshotFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestScreenshotFlow.swift; sourceTree = "<group>"; };
 		B12D2A9F1FC69B0700DE78C6 /* NSData+GZIP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+GZIP.h"; sourceTree = "<group>"; };
 		B12D2AA01FC69B0700DE78C6 /* NSData+GZIP.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+GZIP.m"; sourceTree = "<group>"; };
 		B12D2AA21FCB257500DE78C6 /* String+Path.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Path.swift"; sourceTree = "<group>"; };
@@ -221,6 +223,7 @@
 				F3B7EE6D1F22449100E19B57 /* TargetDevice.swift */,
 				F3B7EE711F224A4200E19B57 /* Test.swift */,
 				F3B7EE6F1F2247FA00E19B57 /* TestSummary.swift */,
+				4C70D368219747FD0003015D /* TestScreenshotFlow.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -321,6 +324,7 @@
 				F3B7EE701F2247FA00E19B57 /* TestSummary.swift in Sources */,
 				F3B7EE6C1F2242DC00E19B57 /* Summary.swift in Sources */,
 				F306675E1F2A1BEC00EDE682 /* BackgroundColor.swift in Sources */,
+				4C70D369219747FD0003015D /* TestScreenshotFlow.swift in Sources */,
 				B12D2AA11FC69B0700DE78C6 /* NSData+GZIP.m in Sources */,
 				F3AB011D1F23659D00334580 /* Attachment.swift in Sources */,
 				F324B4A01F22383D00B5B8B4 /* Argument.swift in Sources */,

--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/HTMLTemplates.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/HTMLTemplates.swift
@@ -391,6 +391,11 @@ struct HTMLTemplates
       display:none;
       z-index: 1000;
     }
+    
+    .preview-screenshot {
+        background-color: white;
+        height: 350px;
+    }
 
     #content {
       height: 100%;
@@ -924,6 +929,7 @@ struct HTMLTemplates
     </p>
     [[SUB_TESTS]]
     <div id=\"activities-[[UUID]]\" class=\"activities\">
+    [[SCREENSHOT_FLOW]]
     [[ACTIVITIES]]
     </div>
   </div>

--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Activity.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Activity.swift
@@ -109,12 +109,8 @@ struct Activity: HTML
             "TIME": totalTime.timeString,
             "ACTIVITY_TYPE_CLASS": cssClasses,
             "HAS_SUB-ACTIVITIES_CLASS": (subActivities == nil && (attachments == nil || attachments?.count == 0)) ? "no-drop-down" : "",
-            "SUB_ACTIVITY": subActivities?.reduce("", { (accumulator: String, activity: Activity) -> String in
-                return accumulator + activity.html
-            }) ?? "",
-            "ATTACHMENTS": attachments?.reduce("", { (accumulator: String, attachment: Attachment) -> String in
-                return accumulator + attachment.html
-            }) ?? "",
+            "SUB_ACTIVITY": subActivities?.accumulateHTMLAsString ?? "",
+            "ATTACHMENTS": attachments?.accumulateHTMLAsString ?? "",
         ]
     }
 }

--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Attachment.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Attachment.swift
@@ -50,6 +50,18 @@ struct Attachment: HTML
         self.padding = padding
     }
 
+    var isScreenshot: Bool {
+        if let type = type {
+            switch type {
+            case .png, .jpeg:
+                return true
+            default:
+                return false
+            }
+        }
+        return false
+    }
+
     // PRAGMA MARK: - HTML
 
     var htmlTemplate: String {

--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Test.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Test.swift
@@ -55,6 +55,7 @@ struct Test: HTML
     var activities: [Activity]?
     var status: Status
     var objectClass: ObjectClass
+    var testScreenshotFlow: TestScreenshotFlow?
 
     var allSubTests: [Test]? {
         guard subTests != nil else {
@@ -98,6 +99,7 @@ struct Test: HTML
 
         let rawStatus = dict["TestStatus"] as? String ?? ""
         status = Status(rawValue: rawStatus)!
+        testScreenshotFlow = TestScreenshotFlow(activities: activities)
     }
 
     // PRAGMA MARK: - HTML
@@ -109,16 +111,13 @@ struct Test: HTML
             "UUID": uuid,
             "NAME": name + (amountSubTests > 0 ? " - \(amountSubTests) tests" : ""),
             "TIME": duration.timeString,
-            "SUB_TESTS": subTests?.reduce("", { (accumulator: String, test: Test) -> String in
-                return accumulator + test.html
-            }) ?? "",
+            "SUB_TESTS": subTests?.accumulateHTMLAsString ?? "",
             "HAS_ACTIVITIES_CLASS": (activities == nil) ? "no-drop-down" : "",
-            "ACTIVITIES": activities?.reduce("", { (accumulator: String, activity: Activity) -> String in
-                return accumulator + activity.html
-            }) ?? "",
+            "ACTIVITIES": activities?.accumulateHTMLAsString ?? "",
             "ICON_CLASS": status.cssClass,
             "ITEM_CLASS": objectClass.cssClass,
-			"LIST_ITEM_CLASS": objectClass == .testSummary ? (status == .failure ? "list-item list-item-failed" : "list-item") : ""
+			"LIST_ITEM_CLASS": objectClass == .testSummary ? (status == .failure ? "list-item list-item-failed" : "list-item") : "",
+            "SCREENSHOT_FLOW": testScreenshotFlow?.screenshots.accumulateHTMLAsString ?? ""
         ]
     }
 }

--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/TestScreenshotFlow.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/TestScreenshotFlow.swift
@@ -1,0 +1,66 @@
+//
+//  TestScreenshotFlow.swift
+//  XCTestHTMLReport
+//
+//  Created by Alistair Leszkiewicz on 11/10/18.
+//  Copyright © 2018 Tito. All rights reserved.
+//
+
+import Foundation
+
+struct TestScreenshotFlow
+{
+    var screenshots: [ScreenshotAttachment]
+    
+    init?(activities: [Activity]?) {
+        guard let activities = activities else {
+            return nil
+        }
+        
+        let anyScreenshots = activities.trueForAny { !$0.screenshotAttachments.isEmpty }
+        guard anyScreenshots else {
+            return nil
+        }
+        screenshots = activities.flatMap { $0.screenshotAttachments.map { ScreenshotAttachment(attachment: $0) } }
+    }
+    
+}
+
+fileprivate extension Sequence {
+    // Determines whether any element in the Array matches the conditions defined by the specified predicate.
+    func trueForAny(_ predicate: (Element) -> Bool) -> Bool {
+        return first(where: predicate) != nil
+    }
+}
+
+fileprivate extension Activity {
+    
+    var screenshotAttachments: [Attachment] {
+        return attachments?.compactMap({ $0 }).filter { $0.isScreenshot } ?? []
+        + subScreenshotAttachments
+    }
+    
+    var subScreenshotAttachments: [Attachment] {
+        return subActivities?.compactMap({ $0 }).flatMap({ $0.screenshotAttachments }) ?? []
+    }
+}
+
+
+struct ScreenshotAttachment: HTML {
+    let attachment: Attachment
+    
+    static let screenshot = """
+  <img class=\"preview-screenshot\" src=\"[[PATH]]/Attachments/[[FILENAME]]\" id=\"screenshot-[[FILENAME]]\"/>
+  """
+    
+    var htmlTemplate: String {
+        return ScreenshotAttachment.screenshot
+    }
+
+    var htmlPlaceholderValues: [String: String] {
+        return [
+            "PATH": attachment.path,
+            "FILENAME": attachment.filename
+        ]
+    }
+}

--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/TestSummary.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/TestSummary.swift
@@ -65,9 +65,7 @@ struct TestSummary: HTML
     var htmlPlaceholderValues: [String: String] {
         return [
             "UUID": uuid,
-            "TESTS": tests.reduce("", { (accumulator: String, test: Test) -> String in
-                return accumulator + test.html
-            })
+            "TESTS": tests.accumulateHTMLAsString
         ]
     }
 }

--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/Protocols/HTML.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/Protocols/HTML.swift
@@ -14,6 +14,16 @@ protocol HTML
     var htmlPlaceholderValues: [String: String] { get }
 }
 
+extension Sequence where Element : HTML {
+
+    var accumulateHTMLAsString: String {
+        return reduce("", { (accumulator: String, element: HTML) -> String in
+            return accumulator + element.html
+        })
+    }
+
+}
+
 extension HTML
 {
     var html: String {

--- a/XCTestHTMLReport/XCTestHTMLReport/HTML/index.html
+++ b/XCTestHTMLReport/XCTestHTMLReport/HTML/index.html
@@ -385,6 +385,11 @@
       display:none;
       z-index: 1000;
     }
+    
+    .preview-screenshot {
+        background-color: white;
+        height: 350px;
+    }
 
     #content {
       height: 100%;

--- a/XCTestHTMLReport/XCTestHTMLReport/HTML/test.html
+++ b/XCTestHTMLReport/XCTestHTMLReport/HTML/test.html
@@ -7,6 +7,7 @@
     </p>
     [[SUB_TESTS]]
     <div id="activities-[[UUID]]" class="activities">
+    [[SCREENSHOT_FLOW]]
     [[ACTIVITIES]]
     </div>
   </div>


### PR DESCRIPTION
@TitouanVanBelle As I suggested here https://github.com/TitouanVanBelle/XCTestHTMLReport/issues/105 I wanted a way to see all screenshot attachments for failing UI tests. I added new HTML inserted string at the start of each test to show some small screenshots inline. This we help diagnose failures in UI tests with less clicking to expand. 

Here's an example being used at Grubhub - I reduced the zoom level in chrome so you can see the entire journey taken

![image](https://user-images.githubusercontent.com/501631/48304912-1aefb080-e4f0-11e8-8b76-4b9a6fcdf6b6.png)

I also added `accumulateHTMLAsString` to remove the number of repeated `reduce` calls
