### PR TITLE
Spike:  Aggregate device failures into a new section called 'All results' which shows all tests across all devices

### DIFF
--- a/XCTestHTMLReport/XCTestHTMLReport.xcodeproj/project.pbxproj
+++ b/XCTestHTMLReport/XCTestHTMLReport.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0994F3C92175C16A003988B4 /* String+Path.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0994F3C82175C16A003988B4 /* String+Path.swift */; };
 		0994F3CB2175C1B7003988B4 /* String+Xml.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0994F3CA2175C1B7003988B4 /* String+Xml.swift */; };
+		4C17A71D21B16A2300585DFB /* JoinedRuns.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C17A71C21B16A2300585DFB /* JoinedRuns.swift */; };
 		B12D2AA11FC69B0700DE78C6 /* NSData+GZIP.m in Sources */ = {isa = PBXBuildFile; fileRef = B12D2AA01FC69B0700DE78C6 /* NSData+GZIP.m */; };
 		D980EDD4209123E400CABFE7 /* JUnitReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D980EDD3209123DB00CABFE7 /* JUnitReport.swift */; };
 		F30667381F2A0DE900EDE682 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30667371F2A0DE900EDE682 /* Logger.swift */; };
@@ -56,6 +57,7 @@
 /* Begin PBXFileReference section */
 		0994F3C82175C16A003988B4 /* String+Path.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Path.swift"; sourceTree = "<group>"; };
 		0994F3CA2175C1B7003988B4 /* String+Xml.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Xml.swift"; sourceTree = "<group>"; };
+		4C17A71C21B16A2300585DFB /* JoinedRuns.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JoinedRuns.swift; sourceTree = "<group>"; };
 		B12D2A9F1FC69B0700DE78C6 /* NSData+GZIP.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+GZIP.h"; sourceTree = "<group>"; };
 		B12D2AA01FC69B0700DE78C6 /* NSData+GZIP.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+GZIP.m"; sourceTree = "<group>"; };
 		D980EDD3209123DB00CABFE7 /* JUnitReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JUnitReport.swift; sourceTree = "<group>"; };
@@ -224,6 +226,7 @@
 				F3B7EE6D1F22449100E19B57 /* TargetDevice.swift */,
 				F3B7EE711F224A4200E19B57 /* Test.swift */,
 				F3B7EE6F1F2247FA00E19B57 /* TestSummary.swift */,
+				4C17A71C21B16A2300585DFB /* JoinedRuns.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -337,6 +340,7 @@
 				F30667611F2A1BEC00EDE682 /* ControlCode.swift in Sources */,
 				F3B7EE721F224A4200E19B57 /* Test.swift in Sources */,
 				F353A1471F9B454D00E5A528 /* Run.swift in Sources */,
+				4C17A71D21B16A2300585DFB /* JoinedRuns.swift in Sources */,
 				F30667641F2A1BEC00EDE682 /* Rainbow.swift in Sources */,
 				F30667551F2A1BE200EDE682 /* Style.swift in Sources */,
 				F30667651F2A1BEC00EDE682 /* String+Rainbow.swift in Sources */,

--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/HTMLTemplates.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/HTMLTemplates.swift
@@ -538,6 +538,17 @@ struct HTMLTemplates
       <div id=\"container\">
         <div id=\"left-sidebar\" class=\"sidebar\">
           <div class=\"resizer\"></div>
+          <h4 id=\"device-header\">All tests</h4>
+          <ul id=\"info-sections\">
+              <li class=\"section\">
+                  <ul class=\"device-info\" onclick=\"selectDevice('ALL', this);\">
+                      <li><span class=\"device-result icon left failure\"></span><h3 class=\"device-name\">All devices</h3></li>
+                      <li class=\"device-os\">Device OS</li>
+                      <li class=\"device-model\">Device Model</li>
+                      <li class=\"device-identifier\">Device Identifier</li>
+                  </ul>
+              </li>
+          </ul>
           <h4 id=\"device-header\">Devices</h4>
           <ul id=\"info-sections\">
             <li class=\"section\">

--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/JoinedRuns.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/JoinedRuns.swift
@@ -1,0 +1,57 @@
+//
+//  JoinedRuns.swift
+//  XCTestHTMLReport
+//
+//  Created by Alistair Leszkiewicz on 11/30/18.
+//  Copyright © 2018 Tito. All rights reserved.
+//
+
+import Foundation
+
+// Represents a series of test runs joined together into a single
+// success / failure run
+struct JoinedRuns : HTML
+{
+    let runs: [Run]
+    
+    init(runs: [Run]) {
+        self.runs = runs
+    }
+
+    var htmlTemplate = HTMLTemplates.run
+
+    var numberOfTests : Int {
+        return runs.map { $0.numberOfTests }.sum()
+    }
+    
+    var numberOfPassedTests : Int {
+        return runs.map { $0.numberOfPassedTests }.sum()
+    }
+    
+    var numberOfFailedTests : Int {
+        return runs.map { $0.numberOfFailedTests }.sum()
+    }
+    
+    var testSummaries: [TestSummary] {
+        return runs.flatMap { $0.testSummaries }
+    }
+    
+    var htmlPlaceholderValues: [String: String] {
+        return [
+            "DEVICE_IDENTIFIER": "ALL",
+            "N_OF_TESTS": String(numberOfTests),
+            "N_OF_PASSED_TESTS": String(numberOfPassedTests),
+            "N_OF_FAILED_TESTS": String(numberOfFailedTests),
+            "TEST_SUMMARIES": testSummaries.map { $0.html }.joined()
+        ]
+    }
+}
+
+
+private extension Array where Element == Int {
+    
+    func sum() -> Int {
+        return reduce(0, +)
+    }
+    
+}

--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/JoinedRuns.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/JoinedRuns.swift
@@ -42,7 +42,7 @@ struct JoinedRuns : HTML
             "N_OF_TESTS": String(numberOfTests),
             "N_OF_PASSED_TESTS": String(numberOfPassedTests),
             "N_OF_FAILED_TESTS": String(numberOfFailedTests),
-            "TEST_SUMMARIES": testSummaries.map { $0.html }.joined()
+            "TEST_SUMMARIES": testSummaries.map { $0.prefixUUIDForJoinedRunWithChildren() }.map { $0.html }.joined()
         ]
     }
 }
@@ -53,5 +53,57 @@ private extension Array where Element == Int {
     func sum() -> Int {
         return reduce(0, +)
     }
+    
+}
+
+/// To keep these UUID's unique within the HTML document
+/// they are all pre-pended with the constant string 'ALL'
+fileprivate protocol JoinedTestSummaryDisplayProtocol {
+    var uuid: String { get set }
+    func prefixUUIDForJoinedRun() -> Self
+    func prefixUUIDForJoinedRunWithChildren() -> Self
+}
+
+fileprivate extension JoinedTestSummaryDisplayProtocol {
+    
+    func prefixUUIDForJoinedRun() -> Self {
+        var copy = self
+        copy.uuid = "ALL-" + copy.uuid
+        return copy
+    }
+    
+    func prefixUUIDForJoinedRunWithChildren() -> Self {
+        return prefixUUIDForJoinedRun()
+    }
+}
+
+extension TestSummary: JoinedTestSummaryDisplayProtocol {
+    
+    func prefixUUIDForJoinedRunWithChildren() -> TestSummary {
+        var copy = self.prefixUUIDForJoinedRun()
+        copy.tests = copy.tests.map { $0.prefixUUIDForJoinedRunWithChildren() }
+        return copy
+    }
+    
+}
+
+extension Test: JoinedTestSummaryDisplayProtocol {
+    
+    func prefixUUIDForJoinedRunWithChildren() -> Test {
+        var copy = self.prefixUUIDForJoinedRun()
+        copy.subTests = copy.subTests?.map { $0.prefixUUIDForJoinedRunWithChildren() }
+        copy.activities = copy.activities?.map { $0.prefixUUIDForJoinedRunWithChildren() }
+        return copy
+    }
+    
+}
+extension Activity: JoinedTestSummaryDisplayProtocol {
+    
+    func prefixUUIDForJoinedRunWithChildren() -> Activity {
+        var copy = self.prefixUUIDForJoinedRun()
+        copy.subActivities = copy.subActivities?.map { $0.prefixUUIDForJoinedRunWithChildren() }
+        return copy
+    }
+
     
 }

--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Run.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Run.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+/// Represents a single test run against a single test device
 struct Run: HTML
 {
     private let activityLogsFilename = "action.xcactivitylog"

--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/RunDestination.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/RunDestination.swift
@@ -31,6 +31,7 @@ private extension Status {
     }
 }
 
+/// Represents single test device attributes
 struct RunDestination : HTML
 {
     var name: String

--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Summary.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Summary.swift
@@ -56,7 +56,7 @@ extension Summary: HTML
             "RESULT_CLASS": runs.reduce(true, { (accumulator: Bool, run: Run) -> Bool in
                 return accumulator && run.status == .success
             }) ? "success" : "failure",
-            "RUNS": runs.map { $0.html }.joined()
+            "RUNS": runs.map { $0.html }.joined() + JoinedRuns(runs: runs).html
         ]
     }
 }

--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Summary.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/Summary.swift
@@ -56,7 +56,7 @@ extension Summary: HTML
             "RESULT_CLASS": runs.reduce(true, { (accumulator: Bool, run: Run) -> Bool in
                 return accumulator && run.status == .success
             }) ? "success" : "failure",
-            "RUNS": runs.map { $0.html }.joined() + JoinedRuns(runs: runs).html
+            "RUNS": JoinedRuns(runs: runs).html + runs.map { $0.html }.joined()
         ]
     }
 }

--- a/XCTestHTMLReport/XCTestHTMLReport/HTML/index.html
+++ b/XCTestHTMLReport/XCTestHTMLReport/HTML/index.html
@@ -532,6 +532,17 @@
       <div id="container">
         <div id="left-sidebar" class="sidebar">
           <div class="resizer"></div>
+          <h4 id="device-header">All tests</h4>
+          <ul id="info-sections">
+              <li class="section">
+                  <ul class="device-info" onclick="selectDevice('ALL', this);">
+                      <li><span class="device-result icon left failure"></span><h3 class="device-name">All devices</h3></li>
+                      <li class="device-os">Device OS</li>
+                      <li class="device-model">Device Model</li>
+                      <li class="device-identifier">Device Identifier</li>
+                  </ul>
+              </li>
+          </ul>
           <h4 id="device-header">Devices</h4>
           <ul id="info-sections">
             <li class="section">


### PR DESCRIPTION
**Note - this is a spike PR, so placing it here to get some feedback. The code provided solves the problem but is not necessarily well architected**

At my company we have started distributing UI tests to run them in parallel and get faster feedback. We coagulate results using `XCTestHTMLReport` and they come back as a per device report. The command to generate the report will take test results from each run is `xchtmlreport -r TestResults-0 -r TestResults-1 ...` where the directory for the test run was copied off of a node that performed the run.

The generated report can have many separate devices that need selecting to be able to see failures, this is time consuming. The PR adds a new section which will show all tests on all devices to alleviate the single device selection. See screenshot. The main difficulty with this implementation was keeping the `UUID` unique in the generated HTML, the current solution to that is to prefix each `UUID` with `ALL` and so the javascript and HTML still work.

![image](https://user-images.githubusercontent.com/501631/49689051-62fef480-fae9-11e8-974e-9aae4e94c841.png)
