### PR TITLE
Fixing support for spaces in project path

### DIFF
--- a/XCTestHTMLReport/XCTestHTMLReport.xcodeproj/project.pbxproj
+++ b/XCTestHTMLReport/XCTestHTMLReport.xcodeproj/project.pbxproj
@@ -306,7 +306,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "echo \"Creating templates\"\n$SRCROOT/Scripts/createTemplates.sh";
+			shellScript = "echo \"Creating templates\"\n\"$SRCROOT/Scripts/createTemplates.sh\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
The project fails to build when there is a space in the path name. Submitted this as bug #117.