### PR TITLE
Fixing test device status not reflecting pass

### DIFF
--- a/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/TestSummary.swift
+++ b/XCTestHTMLReport/XCTestHTMLReport/Classes/Models/TestSummary.swift
@@ -16,14 +16,14 @@ struct TestSummary: HTML
     var status: Status {
         let currentTests = tests
         var status: Status = .unknown
-
-        if currentTests.count == 0 {
-            return .success
-        }
         
         var currentSubtests: [Test] = []
         for test in currentTests {
-            currentSubtests += test.rootSubtests()
+            currentSubtests += test.allTestSummaries()
+        }
+        
+        if currentSubtests.count == 0 {
+            return .success
         }
 
         status = currentSubtests.reduce(.unknown, { (accumulator: Status, test: Test) -> Status in
@@ -70,13 +70,16 @@ struct TestSummary: HTML
 }
 
 extension Test {
-    func rootSubtests() -> [Test] {
-        guard let subTests = self.subTests, subTests.isEmpty == false else {
+    func allTestSummaries() -> [Test] {
+        if self.objectClass == .testSummary {
             return [self]
+        }
+        guard let subTests = self.subTests, subTests.isEmpty == false else {
+            return []
         }
         var testsToReturn: [Test] = []
         for test in subTests {
-            testsToReturn += test.rootSubtests()
+            testsToReturn += test.allTestSummaries()
         }
         return testsToReturn
     }


### PR DESCRIPTION
There was a problem with TestSummary was only querying status one level deep. It looks like this was introduced when the infinite loop problem was fixed in test generation. The loop now won’t run forever, but it also won’t visit every subnode.

I added a recursive function within TestSummary. I’m wondering if in the future this recursive querying shouldn’t be added into the model layer instead. But this change should fix the issue without adding too much refactoring or risk of further issue into the project itself.