### PR TITLE
Fix Xcode 10.2 build to look for Swift frameworks correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
-osx_image: xcode9.3
+osx_image: 
+  - xcode9.3
+  - xcode10.1
+  - xcode10.2
+  
 language: objective-c
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@ osx_image:
   - xcode9.3
   - xcode10.1
   - xcode10.2
-  
+
 language: objective-c
 
-before_script:
-  - bundle install
 script:
-  - set -o pipefail
+  - set -o pipefail && xcodebuild clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -workspace XCTestHTMLReport.xcworkspace -scheme XCTestHTMLReport -configuration Release | xcpretty
+  - ./xchtmlreport -h

--- a/XCTestHTMLReport/XCTestHTMLReport.xcodeproj/project.pbxproj
+++ b/XCTestHTMLReport/XCTestHTMLReport.xcodeproj/project.pbxproj
@@ -469,7 +469,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/..";
 				DEVELOPMENT_TEAM = "";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				PRODUCT_NAME = xchtmlreport;
 				SWIFT_OBJC_BRIDGING_HEADER = "XCTestHTMLReport/Libraries/XCTestHTMLReport-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -484,7 +484,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/..";
 				DEVELOPMENT_TEAM = "";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				PRODUCT_NAME = xchtmlreport;
 				SWIFT_OBJC_BRIDGING_HEADER = "XCTestHTMLReport/Libraries/XCTestHTMLReport-Bridging-Header.h";
 				SWIFT_VERSION = 4.0;


### PR DESCRIPTION
Xcode 10.2 is in beta, and `xchtmlreport` built with it crashes because it can't find Swift shared libraries.

This PR fixes the runpath to look in the current toolchain for these libraries.

In addition, I've added an Xcode version matrix to include 9.3, 10.1 & 10.2.

I've also made Travis build and run `./xchtmlreport -h` to see that it can load correctly.