### PR TITLE
Disables sandbox on `swift build`

### DIFF
--- a/xchtmlreport.rb
+++ b/xchtmlreport.rb
@@ -6,7 +6,7 @@ class Xchtmlreport < Formula
   head "https://github.com/TitouanVanBelle/XCTestHTMLReport.git", :branch => "develop"
 
   def install
-    system "swift build -c release"
+    system "swift build --disable-sandbox -c release"
     bin.install ".build/release/xchtmlreport"
   end
 end


### PR DESCRIPTION
Hello 👋

When trying to install the new version that is compatible with Xcode 11.1 and macOS Catalina, I get the following error:

```
Desktop ➜ brew bundle install
######################################################################## 100.0%
==> Cloning https://github.com/TitouanVanBelle/XCTestHTMLReport.git
==> Checking out branch develop
Already on 'develop'
Your branch is up to date with 'origin/develop'.
HEAD is now at 2ca39c5 Merge pull request #141 from felginep/feature/xcode11
==> swift build -c release
Last 15 lines from /Users/ivosilva/Library/Logs/Homebrew/xchtmlreport/01.swift:
2019-10-22 15:14:08 +0100

swift build -c release

/private/tmp/xchtmlreport-20191022-67560-7l7cd6: error: manifest parse error(s):
sandbox-exec: sandbox_apply: Operation not permitted

Do not report this issue to Homebrew/brew or Homebrew/core!
```

The goal of this PR is to fix this error and enable the install in Catalina.

Although, it would be good to have a bit more clarity on what is causing the need to explicitly disable sandboxing on this version 🕵️‍♂️