### PR TITLE
Fix Homebrew for 2.0.0 release

### DIFF
--- a/xchtmlreport.rb
+++ b/xchtmlreport.rb
@@ -2,11 +2,11 @@ class Xchtmlreport < Formula
   desc "XCTestHTMLReport: Xcode-like HTML report for Unit and UI Tests"
   homepage "https://github.com/TitouanVanBelle/XCTestHTMLReport"
   url "https://github.com/TitouanVanBelle/XCTestHTMLReport/archive/2.0.0.tar.gz"
-  sha256 "6e0e3c30331bb32bbf38ebd438c1ee3a168432c10ece0f0292c7fdbb72483e0c"
+  sha256 "4424d673d578e84e67fd96afa53a5bd3e80ec7acade65365a123af358c77b47e"
   head "https://github.com/TitouanVanBelle/XCTestHTMLReport.git", :branch => "develop"
 
   def install
-    system "swift build -c release"
+    system "swift build --disable-sandbox -c release"
     bin.install ".build/release/xchtmlreport"
   end
 end


### PR DESCRIPTION
Apparently the Swift compiler doesn't like being in a double sandbox: https://github.com/yonaskolb/XcodeGen/issues/51#issuecomment-331615462