### PR TITLE
Make it possible to inline assets into the resulting index.html

### DIFF
--- a/Sources/XCTestHTMLReport/Classes/HTMLTemplates.swift
+++ b/Sources/XCTestHTMLReport/Classes/HTMLTemplates.swift
@@ -951,7 +951,7 @@ struct HTMLTemplates
     <span class=\"icon left screenshot-icon\" style=\"margin-left: [[PADDING]]px\"></span>
     [[NAME]]
     <span class=\"icon preview-icon\" data=\"[[FILENAME]]\" onclick=\"showScreenshot('[[FILENAME]]')\"></span>
-    <img class=\"screenshot\" src=\"[[SRC]]\" id=\"screenshot-[[FILENAME]]\"/>
+    <img class=\"screenshot\" src=\"[[SOURCE]]\" id=\"screenshot-[[FILENAME]]\"/>
   </p>
   """
 

--- a/Sources/XCTestHTMLReport/Classes/HTMLTemplates.swift
+++ b/Sources/XCTestHTMLReport/Classes/HTMLTemplates.swift
@@ -903,7 +903,7 @@ struct HTMLTemplates
           <li class=\"selected\">All Messages</li>
         </ul>
       </div>
-      <iframe id=\"logs-iframe\" src=\"[[LOG_PATH]]\"></iframe>
+      <iframe id=\"logs-iframe\" src=\"[[LOG_SOURCE]]\"></iframe>
     </div>
   </div>
   """
@@ -959,7 +959,7 @@ struct HTMLTemplates
   <p class=\"attachment list-item\">
     <span class=\"icon left text-icon\" style=\"margin-left: [[PADDING]]px\"></span>
     [[NAME]]
-    <span class=\"icon preview-icon\" data=\"[[PATH]]\" onclick=\"showText('[[PATH]]')\"></span>
+    <span class=\"icon preview-icon\" data=\"[[SOURCE]]\" onclick=\"showText('[[SOURCE]]')\"></span>
   </p>
   """
 }

--- a/Sources/XCTestHTMLReport/Classes/HTMLTemplates.swift
+++ b/Sources/XCTestHTMLReport/Classes/HTMLTemplates.swift
@@ -951,7 +951,7 @@ struct HTMLTemplates
     <span class=\"icon left screenshot-icon\" style=\"margin-left: [[PADDING]]px\"></span>
     [[NAME]]
     <span class=\"icon preview-icon\" data=\"[[FILENAME]]\" onclick=\"showScreenshot('[[FILENAME]]')\"></span>
-    <img class=\"screenshot\" src=\"[[PATH]]\" id=\"screenshot-[[FILENAME]]\"/>
+    <img class=\"screenshot\" src=\"[[SRC]]\" id=\"screenshot-[[FILENAME]]\"/>
   </p>
   """
 

--- a/Sources/XCTestHTMLReport/Classes/Models/Activity.swift
+++ b/Sources/XCTestHTMLReport/Classes/Models/Activity.swift
@@ -71,17 +71,17 @@ struct Activity: HTML
         return cls
     }
 
-    init(summary: ActionTestActivitySummary, file: ResultFile, padding: Int = 0) {
+    init(summary: ActionTestActivitySummary, file: ResultFile, padding: Int = 0, renderingMode: Summary.RenderingMode) {
         self.uuid = summary.uuid
         self.startTime = summary.start?.timeIntervalSince1970 ?? 0
         self.finishTime = summary.finish?.timeIntervalSince1970 ?? 0
         self.title = summary.title
         self.subActivities = summary.subactivities.map {
-            Activity(summary: $0, file: file, padding: padding + 10)
+            Activity(summary: $0, file: file, padding: padding + 10, renderingMode: renderingMode)
         }
         self.type = ActivityType(rawValue: summary.activityType)
         self.attachments = summary.attachments.map {
-            Attachment(attachment: $0, file: file, padding: padding + 16)
+            Attachment(attachment: $0, file: file, padding: padding + 16, renderingMode: renderingMode)
         }
         self.padding = padding
     }

--- a/Sources/XCTestHTMLReport/Classes/Models/Attachment.swift
+++ b/Sources/XCTestHTMLReport/Classes/Models/Attachment.swift
@@ -113,7 +113,7 @@ struct Attachment: HTML
         return url?.relativePath
     }
 
-    private var src: String? {
+    private var source: String? {
         switch renderingMode {
         case .inline: return base64data
         case .linking: return path
@@ -145,7 +145,7 @@ struct Attachment: HTML
     var htmlPlaceholderValues: [String: String] {
         return [
             "PADDING": String(padding),
-            "SRC": src ?? "",
+            "SOURCE": source ?? "",
             "FILENAME": filename,
             "NAME": displayName
         ]

--- a/Sources/XCTestHTMLReport/Classes/Models/RenderingContent.swift
+++ b/Sources/XCTestHTMLReport/Classes/Models/RenderingContent.swift
@@ -1,0 +1,14 @@
+//
+//  RenderingContent.swift
+//  XCTestHTMLReport
+//
+//  Created by Pierre Felgines on 09/12/2019.
+//
+
+import Foundation
+
+enum RenderingContent {
+    case data(Data)
+    case url(URL)
+    case none
+}

--- a/Sources/XCTestHTMLReport/Classes/Models/ResultFile.swift
+++ b/Sources/XCTestHTMLReport/Classes/Models/ResultFile.swift
@@ -39,6 +39,19 @@ class ResultFile {
         }
     }
 
+    func exportPayloadData(id: String) -> Data? {
+        guard let savedURL = file.exportPayload(id: id) else {
+            Logger.warning("Can't export payload with id \(id)")
+            return nil
+        }
+        do {
+            return try Data(contentsOf: savedURL)
+        } catch {
+            Logger.warning("Can't get content of \(savedURL)")
+            return nil
+        }
+    }
+
     func getInvocationRecord() -> ActionsInvocationRecord? {
         return file.getInvocationRecord()
     }
@@ -71,5 +84,35 @@ class ResultFile {
             return nil
         }
     }
+
+    func exportLogsData(id: String) -> Data? {
+        guard let logSection = file.getLogs(id: id) else {
+            Logger.warning("Can't get logss with id \(id)")
+            return nil
+        }
+        return logSection.emittedOutput?.data(using: .utf8)
+    }
 }
 
+extension ResultFile {
+
+    func exportPayloadContent(id: String,
+                              renderingMode: Summary.RenderingMode) -> RenderingContent {
+        switch renderingMode {
+        case .inline:
+            return exportPayloadData(id: id).map(RenderingContent.data) ?? .none
+        case .linking:
+            return exportPayload(id: id).map(RenderingContent.url) ?? .none
+        }
+    }
+
+    func exportLogsContent(id: String,
+                           renderingMode: Summary.RenderingMode) -> RenderingContent {
+        switch renderingMode {
+        case .inline:
+            return exportLogsData(id: id).map(RenderingContent.data) ?? .none
+        case .linking:
+            return exportLogs(id: id).map(RenderingContent.url) ?? .none
+        }
+    }
+}

--- a/Sources/XCTestHTMLReport/Classes/Models/Run.swift
+++ b/Sources/XCTestHTMLReport/Classes/Models/Run.swift
@@ -13,7 +13,7 @@ struct Run: HTML
 {
     let runDestination: RunDestination
     let testSummaries: [TestSummary]
-    let logPath: String
+    let logContent: RenderingContent
     var status: Status {
        return testSummaries.reduce(true, { (accumulator: Bool, summary: TestSummary) -> Bool in
             return accumulator && summary.status == .success
@@ -50,16 +50,29 @@ struct Run: HTML
 
         // TODO: (Pierre Felgines) 02/10/2019 Use only emittedOutput from logs objects
         // For now XCResultKit do not handle logs
-        if let logReference = action.actionResult.logRef,
-            let url = file.exportLogs(id: logReference.id) {
-            self.logPath = url.relativePath
+        if let logReference = action.actionResult.logRef {
+            self.logContent = file.exportLogsContent(
+                id: logReference.id,
+                renderingMode: renderingMode
+            )
         } else {
             Logger.warning("Can't find test reference for action \(action.title ?? "")")
-            self.logPath = ""
+            self.logContent = .none
         }
         self.testSummaries = testPlanSummaries.summaries
             .flatMap { $0.testableSummaries }
             .map { TestSummary(summary: $0, file: file, renderingMode: renderingMode) }
+    }
+
+    private var logSource: String? {
+        switch logContent {
+        case let .url(url):
+            return url.relativePath
+        case let .data(data):
+            return "data:text/plain;base64,\(data.base64EncodedString())"
+        case .none:
+            return nil
+        }
     }
 
     // PRAGMA MARK: - HTML
@@ -69,7 +82,7 @@ struct Run: HTML
     var htmlPlaceholderValues: [String: String] {
         return [
             "DEVICE_IDENTIFIER": runDestination.targetDevice.uniqueIdentifier,
-            "LOG_PATH": logPath,
+            "LOG_SOURCE": logSource ?? "",
             "N_OF_TESTS": String(numberOfTests),
             "N_OF_PASSED_TESTS": String(numberOfPassedTests),
             "N_OF_FAILED_TESTS": String(numberOfFailedTests),

--- a/Sources/XCTestHTMLReport/Classes/Models/Run.swift
+++ b/Sources/XCTestHTMLReport/Classes/Models/Run.swift
@@ -38,7 +38,7 @@ struct Run: HTML
         return allTests.filter { $0.status == .failure }.count
     }
 
-    init?(action: ActionRecord, file: ResultFile) {
+    init?(action: ActionRecord, file: ResultFile, renderingMode: Summary.RenderingMode) {
         self.runDestination = RunDestination(record: action.runDestination)
 
         guard
@@ -59,7 +59,7 @@ struct Run: HTML
         }
         self.testSummaries = testPlanSummaries.summaries
             .flatMap { $0.testableSummaries }
-            .map { TestSummary(summary: $0, file: file) }
+            .map { TestSummary(summary: $0, file: file, renderingMode: renderingMode) }
     }
 
     // PRAGMA MARK: - HTML

--- a/Sources/XCTestHTMLReport/Classes/Models/Summary.swift
+++ b/Sources/XCTestHTMLReport/Classes/Models/Summary.swift
@@ -13,7 +13,12 @@ struct Summary
 {
     let runs: [Run]
 
-    init(resultPaths: [String]) {
+    enum RenderingMode {
+        case inline
+        case linking
+    }
+
+    init(resultPaths: [String], renderingMode: RenderingMode) {
         var runs: [Run] = []
         for resultPath in resultPaths {
             Logger.step("Parsing \(resultPath)")
@@ -24,7 +29,7 @@ struct Summary
                 break
             }
             let resultRuns = invocationRecord.actions.compactMap {
-                Run(action: $0, file: resultFile)
+                Run(action: $0, file: resultFile, renderingMode: renderingMode)
             }
             runs.append(contentsOf: resultRuns)
         }

--- a/Sources/XCTestHTMLReport/Classes/Models/Test.swift
+++ b/Sources/XCTestHTMLReport/Classes/Models/Test.swift
@@ -70,22 +70,22 @@ struct Test: HTML
         return a == 0 ? subTests.count : a
     }
 
-    init(group: ActionTestSummaryGroup, file: ResultFile) {
+    init(group: ActionTestSummaryGroup, file: ResultFile, renderingMode: Summary.RenderingMode) {
         self.uuid = NSUUID().uuidString
         self.identifier = group.identifier
         self.duration = group.duration
         self.name = group.name
         if group.subtests.isEmpty {
-            self.subTests = group.subtestGroups.map { Test(group: $0, file: file) }
+            self.subTests = group.subtestGroups.map { Test(group: $0, file: file, renderingMode: renderingMode) }
         } else {
-            self.subTests = group.subtests.map { Test(metadata: $0, file: file) }
+            self.subTests = group.subtests.map { Test(metadata: $0, file: file, renderingMode: renderingMode) }
         }
         self.objectClass = .testSummaryGroup
         self.activities = []
         self.status = .unknown // ???: Usefull?
     }
 
-    init(metadata: ActionTestMetadata, file: ResultFile) {
+    init(metadata: ActionTestMetadata, file: ResultFile, renderingMode: Summary.RenderingMode) {
         self.uuid = NSUUID().uuidString
         self.identifier = metadata.identifier
         self.duration = metadata.duration ?? 0
@@ -96,7 +96,7 @@ struct Test: HTML
         if let id = metadata.summaryRef?.id,
             let actionTestSummary = file.getActionTestSummary(id: id) {
             self.activities = actionTestSummary.activitySummaries.map {
-                Activity(summary: $0, file: file, padding: 20)
+                Activity(summary: $0, file: file, padding: 20, renderingMode: renderingMode)
             }
         } else {
             self.activities = []

--- a/Sources/XCTestHTMLReport/Classes/Models/TestSummary.swift
+++ b/Sources/XCTestHTMLReport/Classes/Models/TestSummary.swift
@@ -46,10 +46,10 @@ struct TestSummary: HTML
         return status
     }
 
-    init(summary: ActionTestableSummary, file: ResultFile) {
+    init(summary: ActionTestableSummary, file: ResultFile, renderingMode: Summary.RenderingMode) {
         self.uuid = UUID().uuidString
         self.testName = summary.targetName ?? ""
-        self.tests = summary.tests.map { Test(group: $0, file: file) }
+        self.tests = summary.tests.map { Test(group: $0, file: file, renderingMode: renderingMode) }
     }
 
     // PRAGMA MARK: - HTML

--- a/Sources/XCTestHTMLReport/HTML/run.html
+++ b/Sources/XCTestHTMLReport/HTML/run.html
@@ -19,6 +19,6 @@
           <li class="selected">All Messages</li>
         </ul>
       </div>
-      <iframe id="logs-iframe" src="[[LOG_PATH]]"></iframe>
+      <iframe id="logs-iframe" src="[[LOG_SOURCE]]"></iframe>
     </div>
   </div>

--- a/Sources/XCTestHTMLReport/HTML/screenshot.html
+++ b/Sources/XCTestHTMLReport/HTML/screenshot.html
@@ -2,5 +2,5 @@
     <span class="icon left screenshot-icon" style="margin-left: [[PADDING]]px"></span>
     [[NAME]]
     <span class="icon preview-icon" data="[[FILENAME]]" onclick="showScreenshot('[[FILENAME]]')"></span>
-    <img class="screenshot" src="[[SRC]]" id="screenshot-[[FILENAME]]"/>
+    <img class="screenshot" src="[[SOURCE]]" id="screenshot-[[FILENAME]]"/>
   </p>

--- a/Sources/XCTestHTMLReport/HTML/screenshot.html
+++ b/Sources/XCTestHTMLReport/HTML/screenshot.html
@@ -2,5 +2,5 @@
     <span class="icon left screenshot-icon" style="margin-left: [[PADDING]]px"></span>
     [[NAME]]
     <span class="icon preview-icon" data="[[FILENAME]]" onclick="showScreenshot('[[FILENAME]]')"></span>
-    <img class="screenshot" src="[[PATH]]" id="screenshot-[[FILENAME]]"/>
+    <img class="screenshot" src="[[SRC]]" id="screenshot-[[FILENAME]]"/>
   </p>

--- a/Sources/XCTestHTMLReport/HTML/text.html
+++ b/Sources/XCTestHTMLReport/HTML/text.html
@@ -1,5 +1,5 @@
   <p class="attachment list-item">
     <span class="icon left text-icon" style="margin-left: [[PADDING]]px"></span>
     [[NAME]]
-    <span class="icon preview-icon" data="[[PATH]]" onclick="showText('[[PATH]]')"></span>
+    <span class="icon preview-icon" data="[[SOURCE]]" onclick="showText('[[SOURCE]]')"></span>
   </p>

--- a/Sources/XCTestHTMLReport/main.swift
+++ b/Sources/XCTestHTMLReport/main.swift
@@ -17,15 +17,19 @@ var junit = BlockArgument("j", "junit", required: false, helpMessage: "Provide J
     junitEnabled = true
 }
 var result = ValueArgument(.path, "r", "resultBundlePath", required: true, allowsMultiple: true, helpMessage: "Path to a result bundle (allows multiple)")
+var renderingMode = Summary.RenderingMode.linking
+var inlineAssets = BlockArgument("i", "inlineAssets", required: false, helpMessage: "Inline all assets in the resulting html-file, making it heavier, but more portable") {
+    renderingMode = .inline
+}
 
-command.arguments = [help, verbose, junit, result]
+command.arguments = [help, verbose, junit, result, inlineAssets]
 
 if !command.isValid {
     print(command.usage)
     exit(EXIT_FAILURE)
 }
 
-let summary = Summary(resultPaths: result.values)
+let summary = Summary(resultPaths: result.values, renderingMode: renderingMode)
 
 Logger.step("Building HTML..")
 let html = summary.html


### PR DESCRIPTION
## What
This PR adds a CLI-option `-i Inline all assets in the resulting html-file, making it heavier, but more portable`, passing this in will inline images in the resulting `index.html`

## Why
When e.g. using this in a CI it's very useful to be able to have a single artifact that can be downloaded/stored in some way, this enables that.
We're e.g. using CircleCI, where it's possible to upload artifacts that can later be accessed as a webpage, having to upload the whole directory makes this very slow, and it also seems to occasionally drop links to images.