### PR TITLE
Fix crash in XCResultKit: XCResultKit updated

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/davidahouse/XCResultKit.git",
         "state": {
           "branch": null,
-          "revision": "a3c59768f90c0a0945ef1b8576017175f04a54b3",
-          "version": "0.4.0"
+          "revision": "06fae51258f83f4fb9919fef7938e0d50a1b0b1d",
+          "version": "0.5.3"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
          .package(url: "https://github.com/onevcat/Rainbow.git", from: "3.0.0"),
-         .package(url: "https://github.com/davidahouse/XCResultKit.git", from: "0.4.0")
+         .package(url: "https://github.com/davidahouse/XCResultKit.git", from: "0.5.3")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
Hi!

There was a crash in XCResultKit, you can look fix here: https://github.com/davidahouse/XCResultKit/pull/18 

Just updated package version. I've tested this solution, it works
