### PR TITLE
Added image resizing, attachment cleanup and screenshot flows

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Sources/XCTestHTMLReport/Classes/Extensions/String+Path.swift
+++ b/Sources/XCTestHTMLReport/Classes/Extensions/String+Path.swift
@@ -10,6 +10,11 @@ import Foundation
 
 extension String
 {
+    func lastPathComponent() -> String
+    {
+        return URL(fileURLWithPath: self).lastPathComponent
+    }
+
     func dropLastPathComponent() -> String
     {
         return URL(fileURLWithPath: self).deletingLastPathComponent().path

--- a/Sources/XCTestHTMLReport/Classes/HTMLTemplates.swift
+++ b/Sources/XCTestHTMLReport/Classes/HTMLTemplates.swift
@@ -392,6 +392,18 @@ struct HTMLTemplates
       z-index: 1000;
     }
 
+    .screenshot-flow {
+        border: 1px solid #021a40;
+        background-color: white;
+        height: 200px;
+    }
+
+    .screenshot-tail {
+        border: 1px solid #021a40;
+        background-color: white;
+        height: 350px;
+    }
+
     #content {
       height: 100%;
       display: flex;
@@ -915,6 +927,7 @@ struct HTMLTemplates
   """
 
   static let test = """
+  [[SCREENSHOT_TAIL]]
   <div class=\"[[ITEM_CLASS]] [[ICON_CLASS]] [[HAS_ACTIVITIES_CLASS]]\">
     <span class=\"icon left test-result-icon\"></span>
     <p class=\"[[LIST_ITEM_CLASS]]\">
@@ -924,6 +937,7 @@ struct HTMLTemplates
     </p>
     [[SUB_TESTS]]
     <div id=\"activities-[[UUID]]\" class=\"activities\">
+    [[SCREENSHOT_FLOW]]
     [[ACTIVITIES]]
     </div>
   </div>

--- a/Sources/XCTestHTMLReport/Classes/Helpers/AttachmentHelpers.swift
+++ b/Sources/XCTestHTMLReport/Classes/Helpers/AttachmentHelpers.swift
@@ -1,0 +1,61 @@
+//
+//  AttachmentHelpers.swift
+//  XCTestHTMLReport
+//
+
+import Foundation
+
+/// MARK: - Helpers
+/// Helpers for location attachments from result model objects
+
+extension Summary {
+
+    var allAttachments: [Attachment] {
+        runs.map({ $0.allAttachments }).reduce([], +)
+    }
+
+}
+
+
+extension Run {
+
+    var screenshotAttachments: [Attachment] {
+        allAttachments.filter { $0.isScreenshot }
+    }
+
+    var allAttachments: [Attachment] {
+        allTests.map({ $0.allAttachments }).reduce([], +)
+    }
+
+}
+
+extension TestSummary {
+
+    var allAttachments: [Attachment] {
+        tests.map({ $0.allAttachments }).reduce([], +)
+    }
+
+}
+
+extension Test {
+
+    var allAttachments: [Attachment] {
+        activities.map({ $0.allAttachments }).reduce([], +)
+    }
+
+}
+
+extension Activity {
+
+    var screenshotAttachments: [Attachment] {
+        return allAttachments.filter { $0.isScreenshot }
+    }
+
+    var allAttachments: [Attachment] {
+        return attachments + subAttachments
+    }
+
+    var subAttachments: [Attachment] {
+        return subActivities.map({ $0.allAttachments }).reduce([], +)
+    }
+}

--- a/Sources/XCTestHTMLReport/Classes/Helpers/ImageHelpers.swift
+++ b/Sources/XCTestHTMLReport/Classes/Helpers/ImageHelpers.swift
@@ -1,0 +1,63 @@
+//
+//  ImageHelpers.swift
+//  XCTestHTMLReport
+//
+
+import Foundation
+import Cocoa
+
+let imageWidth: CGFloat = 200
+let imageCompression: Float = 0.8
+
+/// Performs an image resize for the image at the provided path
+/// image is resized to be 200px width - aspect ratio maintaned
+/// and compressed using jpeg
+/// If the image is already smaller than compression size it
+/// is not modified
+///
+/// - Parameter path: path to an image
+func resizeImage(atPath path: String) -> Bool {
+    guard let image = NSImage(contentsOfFile: path) else {
+        return false
+    }
+    let sizeRatio = imageWidth/image.size.width
+    guard sizeRatio<1.0 else {
+        return false
+    }
+    let resizedImage = resize(image: image,
+                              w: Int(image.size.width*sizeRatio),
+                              h: Int(image.size.height*sizeRatio))
+    let destinationURL = URL(fileURLWithPath: path)
+    resizedImage.jpegWrite(to: destinationURL, options: .atomic, compression: imageCompression)
+    return true
+}
+
+func resize(image: NSImage, w: Int, h: Int) -> NSImage {
+    let destSize = NSMakeSize(CGFloat(w), CGFloat(h))
+    let newImage = NSImage(size: destSize)
+    newImage.lockFocus()
+    image.draw(in: NSMakeRect(0, 0, destSize.width, destSize.height), from: NSMakeRect(0, 0, image.size.width, image.size.height), operation: NSCompositingOperation.sourceOver, fraction: CGFloat(1))
+    newImage.unlockFocus()
+    newImage.size = destSize
+    return NSImage(data: newImage.tiffRepresentation!)!
+}
+
+extension NSImage {
+
+    func jpegData(compression: Float) -> Data? {
+        guard let tiffRepresentation = tiffRepresentation, let bitmapImage = NSBitmapImageRep(data: tiffRepresentation) else { return nil }
+        return bitmapImage.representation(using: .jpeg, properties: [ NSBitmapImageRep.PropertyKey.compressionFactor : NSNumber(value: compression)])
+    }
+
+    @discardableResult
+    func jpegWrite(to url: URL, options: Data.WritingOptions = .atomic, compression: Float) -> Bool {
+        do {
+            try jpegData(compression: compression)?.write(to: url, options: options)
+            return true
+        } catch {
+            Logger.error("Image write error: " + error.localizedDescription)
+            return false
+        }
+    }
+
+}

--- a/Sources/XCTestHTMLReport/Classes/Helpers/UnattachedFiles.swift
+++ b/Sources/XCTestHTMLReport/Classes/Helpers/UnattachedFiles.swift
@@ -1,0 +1,54 @@
+//
+//  UnattachedFiles.swift
+//
+
+import Foundation
+
+func removeUnattachedFiles(run: Run) -> Int {
+    let skippedFiles = ["report.junit"]
+    let fileManager = FileManager.default
+    var removedFiles = 0
+    var attachmentPathsLastItem = run.allAttachments.map { $0.source?.lastPathComponent() }
+    if case RenderingContent.url(let url) = run.logContent {
+        attachmentPathsLastItem.append(url.lastPathComponent)
+    }
+
+    func shouldBeDeleted(fileURL: URL) -> Bool {
+        /// Do not delete directories
+        var isDir: ObjCBool = false
+        if fileManager.fileExists(atPath: fileURL.path, isDirectory: &isDir), isDir.boolValue {
+            return false
+        }
+
+        let lastPathComponent = fileURL.lastPathComponent
+
+        if attachmentPathsLastItem.contains(lastPathComponent) {
+            return false
+        }
+
+        if skippedFiles.contains(lastPathComponent) {
+            return false
+        }
+
+        return true
+    }
+
+    func searchFileURLs() throws -> [URL] {
+        let topContents = try fileManager.contentsOfDirectory(at: run.file.url, includingPropertiesForKeys: nil)
+        let dataContents = try fileManager.contentsOfDirectory(at: run.file.url.appendingPathComponent("Data"), includingPropertiesForKeys: nil)
+        return topContents + dataContents
+    }
+
+    do {
+        for fileURL in try searchFileURLs() {
+            if shouldBeDeleted(fileURL: fileURL) {
+                try fileManager.removeItem(at: fileURL)
+                removedFiles += 1
+            }
+        }
+    } catch {
+        Logger.error("Error while removing files \(error.localizedDescription)")
+    }
+    return removedFiles
+}
+

--- a/Sources/XCTestHTMLReport/Classes/Models/Activity.swift
+++ b/Sources/XCTestHTMLReport/Classes/Models/Activity.swift
@@ -56,7 +56,13 @@ struct Activity: HTML
         return hasDirectAttachment || subActivitesHaveAttachments
     }
     var hasFailingSubActivities: Bool {
-		return subActivities.reduce(false) { $0 || $1.type == .assertionFailure || $1.hasFailingSubActivities }
+		return failingActivityRecursive != nil
+    }
+    var failingActivity: Activity? {
+        return type == .assertionFailure ? self : nil
+    }
+    var failingActivityRecursive: Activity? {
+        return subActivities.first(where: { $0.failingActivityRecursive != nil }) ?? failingActivity
     }
     var cssClasses: String {
         var cls = ""
@@ -99,12 +105,8 @@ struct Activity: HTML
             "TIME": totalTime.timeString,
             "ACTIVITY_TYPE_CLASS": cssClasses,
             "HAS_SUB-ACTIVITIES_CLASS": (subActivities.isEmpty && attachments.isEmpty) ? "no-drop-down" : "",
-            "SUB_ACTIVITY": subActivities.reduce("") { (accumulator: String, activity: Activity) -> String in
-                return accumulator + activity.html
-            },
-            "ATTACHMENTS": attachments.reduce("") { (accumulator: String, attachment: Attachment) -> String in
-                return accumulator + attachment.html
-            },
+            "SUB_ACTIVITY": subActivities.accumulateHTMLAsString,
+            "ATTACHMENTS": attachments.accumulateHTMLAsString,
         ]
     }
 }

--- a/Sources/XCTestHTMLReport/Classes/Models/Attachment.swift
+++ b/Sources/XCTestHTMLReport/Classes/Models/Attachment.swift
@@ -129,6 +129,15 @@ struct Attachment: HTML
             return fallbackDisplayName
         }
     }
+
+    var isScreenshot: Bool {
+        switch type {
+        case .png, .jpeg:
+            return true
+        default:
+            return false
+        }
+    }
     
     // PRAGMA MARK: - HTML
 

--- a/Sources/XCTestHTMLReport/Classes/Models/ResultFile.swift
+++ b/Sources/XCTestHTMLReport/Classes/Models/ResultFile.swift
@@ -10,7 +10,7 @@ import XCResultKit
 
 /// Wrapper of XCResultFile because XCResultFile do not expose `url` property yet
 class ResultFile {
-    private let url: URL
+    let url: URL
     private let relativeUrl: URL
     private let file: XCResultFile
 

--- a/Sources/XCTestHTMLReport/Classes/Models/Run.swift
+++ b/Sources/XCTestHTMLReport/Classes/Models/Run.swift
@@ -11,6 +11,7 @@ import XCResultKit
 
 struct Run: HTML
 {
+    let file: ResultFile
     let runDestination: RunDestination
     let testSummaries: [TestSummary]
     let logContent: RenderingContent
@@ -39,6 +40,7 @@ struct Run: HTML
     }
 
     init?(action: ActionRecord, file: ResultFile, renderingMode: Summary.RenderingMode) {
+        self.file = file
         self.runDestination = RunDestination(record: action.runDestination)
 
         guard

--- a/Sources/XCTestHTMLReport/Classes/Models/Test.swift
+++ b/Sources/XCTestHTMLReport/Classes/Models/Test.swift
@@ -56,6 +56,7 @@ struct Test: HTML
     let activities: [Activity]
     let status: Status
     let objectClass: ObjectClass
+    let testScreenshotFlow: TestScreenshotFlow?
 
     var allSubTests: [Test] {
         return subTests.flatMap { test -> [Test] in
@@ -83,6 +84,7 @@ struct Test: HTML
         self.objectClass = .testSummaryGroup
         self.activities = []
         self.status = .unknown // ???: Usefull?
+        testScreenshotFlow = TestScreenshotFlow(activities: activities)
     }
 
     init(metadata: ActionTestMetadata, file: ResultFile, renderingMode: Summary.RenderingMode) {
@@ -101,6 +103,7 @@ struct Test: HTML
         } else {
             self.activities = []
         }
+        testScreenshotFlow = TestScreenshotFlow(activities: activities)
     }
 
     // PRAGMA MARK: - HTML
@@ -116,12 +119,12 @@ struct Test: HTML
                 return accumulator + test.html
             },
             "HAS_ACTIVITIES_CLASS": activities.isEmpty ? "no-drop-down" : "",
-            "ACTIVITIES": activities.reduce("") { (accumulator: String, activity: Activity) -> String in
-                return accumulator + activity.html
-            },
+            "ACTIVITIES": activities.accumulateHTMLAsString,
             "ICON_CLASS": status.cssClass,
             "ITEM_CLASS": objectClass.cssClass,
-			"LIST_ITEM_CLASS": objectClass == .testSummary ? (status == .failure ? "list-item list-item-failed" : "list-item") : ""
+			"LIST_ITEM_CLASS": objectClass == .testSummary ? (status == .failure ? "list-item list-item-failed" : "list-item") : "",
+            "SCREENSHOT_FLOW": testScreenshotFlow?.screenshots.accumulateHTMLAsString ?? "",
+            "SCREENSHOT_TAIL": testScreenshotFlow?.screenshotsTail.accumulateHTMLAsString ?? ""
         ]
     }
 }

--- a/Sources/XCTestHTMLReport/Classes/Models/TestScreenshotFlow.swift
+++ b/Sources/XCTestHTMLReport/Classes/Models/TestScreenshotFlow.swift
@@ -1,0 +1,49 @@
+//
+//  TestScreenshotFlow.swift
+//  XCTestHTMLReport
+//
+
+import Foundation
+
+struct TestScreenshotFlow
+{
+    var screenshots: [ScreenshotFlowAttachment]
+    var screenshotsTail: [ScreenshotFlowAttachment]
+
+    init?(activities: [Activity]?, tailCount: Int = 3) {
+        guard let activities = activities else {
+            return nil
+        }
+
+        let anyScreenshots = activities.trueForAny { !$0.screenshotAttachments.isEmpty }
+        guard anyScreenshots else {
+            return nil
+        }
+        screenshots = activities.flatMap { $0.screenshotAttachments.map { ScreenshotFlowAttachment(attachment: $0, className: "screenshot-flow") } }
+        screenshotsTail = activities.flatMap { $0.screenshotAttachments.map { ScreenshotFlowAttachment(attachment: $0, className: "screenshot-tail") } }.suffix(3)
+    }
+
+}
+
+fileprivate extension Sequence {
+    // Determines whether any element in the Array matches the conditions defined by the specified predicate.
+    func trueForAny(_ predicate: (Element) -> Bool) -> Bool {
+        return first(where: predicate) != nil
+    }
+}
+
+struct ScreenshotFlowAttachment: HTML {
+    let attachment: Attachment
+    let className: String
+
+    var htmlTemplate: String {
+        return "<img class=\"\(className)\" src=\"[[SRC]]\" id=\"screenshot-[[FILENAME]]\"/>"
+    }
+
+    var htmlPlaceholderValues: [String: String] {
+        return [
+            "SRC": attachment.source ?? "",
+            "FILENAME": attachment.filename
+        ]
+    }
+}

--- a/Sources/XCTestHTMLReport/Classes/Models/TestSummary.swift
+++ b/Sources/XCTestHTMLReport/Classes/Models/TestSummary.swift
@@ -59,9 +59,7 @@ struct TestSummary: HTML
     var htmlPlaceholderValues: [String: String] {
         return [
             "UUID": uuid,
-            "TESTS": tests.reduce("", { (accumulator: String, test: Test) -> String in
-                return accumulator + test.html
-            })
+            "TESTS": tests.accumulateHTMLAsString
         ]
     }
 }

--- a/Sources/XCTestHTMLReport/Classes/Protocols/HTML.swift
+++ b/Sources/XCTestHTMLReport/Classes/Protocols/HTML.swift
@@ -22,3 +22,13 @@ extension HTML
         })
     }
 }
+
+extension Sequence where Element : HTML {
+
+    var accumulateHTMLAsString: String {
+        return reduce("", { (accumulator: String, element: HTML) -> String in
+            return accumulator + element.html
+        })
+    }
+
+}

--- a/Sources/XCTestHTMLReport/HTML/index.html
+++ b/Sources/XCTestHTMLReport/HTML/index.html
@@ -386,6 +386,18 @@
       z-index: 1000;
     }
 
+    .screenshot-flow {
+        border: 1px solid #021a40;
+        background-color: white;
+        height: 200px;
+    }
+
+    .screenshot-tail {
+        border: 1px solid #021a40;
+        background-color: white;
+        height: 350px;
+    }
+
     #content {
       height: 100%;
       display: flex;

--- a/Sources/XCTestHTMLReport/HTML/test.html
+++ b/Sources/XCTestHTMLReport/HTML/test.html
@@ -1,3 +1,4 @@
+  [[SCREENSHOT_TAIL]]
   <div class="[[ITEM_CLASS]] [[ICON_CLASS]] [[HAS_ACTIVITIES_CLASS]]">
     <span class="icon left test-result-icon"></span>
     <p class="[[LIST_ITEM_CLASS]]">
@@ -7,6 +8,7 @@
     </p>
     [[SUB_TESTS]]
     <div id="activities-[[UUID]]" class="activities">
+    [[SCREENSHOT_FLOW]]
     [[ACTIVITIES]]
     </div>
   </div>


### PR DESCRIPTION
Reimplementation of this PR https://github.com/TitouanVanBelle/XCTestHTMLReport/pull/114 compatible with Xcode 11. issue https://github.com/TitouanVanBelle/XCTestHTMLReport/issues/105
Also added some convenience options for reducing the payload size of the results
`-z` to compress images
`-d` to delete any files that are not referenced in the HTML

Also added a screenshot tail, the last 3 failing screenshots. and screenshot flow, to display all screenshots