### PR TITLE
Update XCResultKit to 0.5.7 fixing #166

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/davidahouse/XCResultKit.git",
         "state": {
           "branch": null,
-          "revision": "06fae51258f83f4fb9919fef7938e0d50a1b0b1d",
-          "version": "0.5.3"
+          "revision": "b8cc1631ea91c9e8f9166d58ad607f0278f7553e",
+          "version": "0.5.7"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
          .package(url: "https://github.com/onevcat/Rainbow.git", from: "3.0.0"),
-         .package(url: "https://github.com/davidahouse/XCResultKit.git", from: "0.5.3")
+         .package(url: "https://github.com/davidahouse/XCResultKit.git", from: "0.5.7")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
Bumps XCResultKit to 0.5.7 which fixes #166.

Tested on configuration which was failing with previous v0.5.5 version of XCResultKit: 4 devices with 39 test cases = 156 test cases in total