### PR TITLE
Fix brew ignoring formulae "head" parameter

### DIFF
--- a/xchtmlreport.rb
+++ b/xchtmlreport.rb
@@ -1,7 +1,6 @@
 class Xchtmlreport < Formula
   desc "XCTestHTMLReport: Xcode-like HTML report for Unit and UI Tests"
   homepage "https://github.com/TitouanVanBelle/XCTestHTMLReport"
-  url "https://github.com/TitouanVanBelle/XCTestHTMLReport/archive/2.0.0.tar.gz"
   sha256 "4424d673d578e84e67fd96afa53a5bd3e80ec7acade65365a123af358c77b47e"
   head "https://github.com/TitouanVanBelle/XCTestHTMLReport.git", :branch => "develop"
 


### PR DESCRIPTION
Turns out, when both `url` and `head` are defined in formulae, it downloads sources from `url` ignoring `head`. That leads to installing incorrected/unwanted version, which don't contain fixes in `develop` branch.

Was found because https://github.com/TitouanVanBelle/XCTestHTMLReport/pull/169 kept happing, leaking PIPE file descriptors until crashed while running.