### PR TITLE
Remove dependency on Darwin module

### DIFF
--- a/Sources/XCTestHTMLReport/Classes/Extensions/TimeInterval+Time.swift
+++ b/Sources/XCTestHTMLReport/Classes/Extensions/TimeInterval+Time.swift
@@ -12,7 +12,7 @@ extension TimeInterval
 {
     var timeString: String
     {
-        let ti = NSInteger(self)
+        let ti = Int(self)
 
         let seconds = ti % 60
         let minutes = (ti / 60) % 60

--- a/Sources/XCTestHTMLReport/main.swift
+++ b/Sources/XCTestHTMLReport/main.swift
@@ -1,6 +1,6 @@
-import Darwin
+import Foundation
 
-var version = "2.1.0"
+var version = "2.1.1"
 
 print("XCTestHTMLReport \(version)")
 


### PR DESCRIPTION
### Why this change
Trying to build this using a Swift docker image: https://github.com/apple/swift-docker
Got error on `no such module Darwin`, Replace it with `import Foundation` and now get `NSInteger` not recognized.
Changing it to `Int` resolves this error.

First time doing contribution here, so need guidance on any updates on tests/version number etc. 🙏 