### PR TITLE
Escaping of class names, test names, suite names. Add tests

### DIFF
--- a/Sources/XCTestHTMLReportCore/Classes/Models/JUnitReport.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/JUnitReport.swift
@@ -60,7 +60,7 @@ extension JUnitReport: XMLRepresentable
     /// e.g. <testsuites name='BonMot-iOSTests.xctest' tests='990' failures='2'>
     var xmlString: String {
         var xml = "<?xml version='1.0' encoding='UTF-8'?>\n"
-        xml += "<testsuites name='\(name)' tests='\(tests)' failures='\(failures)'>\n"
+        xml += "<testsuites name='\(name.stringByEscapingXMLChars)' tests='\(tests)' failures='\(failures)'>\n"
 
         suites.forEach { (suite) in
             xml += suite.xmlString
@@ -76,7 +76,7 @@ extension JUnitReport.TestSuite: XMLRepresentable
 {
     /// e.g. <testsuite name='AccessTests' tests='1' failures='0'>
     var xmlString: String {
-        var xml = "  <testsuite name='\(name)' tests='\(tests)' failures='\(failures)'>\n"
+        var xml = "  <testsuite name='\(name.stringByEscapingXMLChars)' tests='\(tests)' failures='\(failures)'>\n"
 
         cases.forEach { (testcase) in
             xml += testcase.xmlString
@@ -93,7 +93,7 @@ extension JUnitReport.TestCase: XMLRepresentable
     /// e.g. <testcase classname='AccessTests' name='testThatThingsThatShouldBePublicArePublic-iPhone8' time='0.007'/>
     var xmlString: String {
         let timeString = String(format: "%.02f", time)
-        var xml = "    <testcase classname='\(classname)' name='\(name)' time='\(timeString)'"
+        var xml = "    <testcase classname='\(classname.stringByEscapingXMLChars)' name='\(name.stringByEscapingXMLChars)' time='\(timeString)'"
 
         if results.isEmpty {
             xml += "/>\n"

--- a/Tests/XCTestHTMLReportTests/JUnitReportTests.swift
+++ b/Tests/XCTestHTMLReportTests/JUnitReportTests.swift
@@ -1,0 +1,59 @@
+//
+//  JUnitReportTests.swift
+//
+//
+//  Created by Guillermo Ignacio Enriquez Gutierrez on 2021/01/17.
+//
+
+import Foundation
+import XCTest
+import NDHpple
+@testable import XCTestHTMLReportCore
+
+final class JUnitReportTests: XCTestCase {
+
+    func testBasicFunctionality() throws {
+        let jUnitReport = JUnitReport(
+            name: "JUnitReportName<'&\\>",
+            suites: [JUnitReport.TestSuite(
+                name: "JUnitReportTestSuiteName<'&\\>",
+                tests: 1,
+                cases: [JUnitReport.TestCase(
+                    classname: "MyClassName<'&\\>",
+                    name: "MyName<'&\\>",
+                    time: 0.002,
+                    state: .failed,
+                    results: [
+                        JUnitReport.TestResult(title: "TitleHere<'&\\>", state: .systemOut),
+                        JUnitReport.TestResult(title: "Assertion Failure: <unknown>:0: Application com.example.test is not running", state: .failed)
+                    ]
+                )]
+            )])
+        let xml = jUnitReport.xmlString
+
+        let parser = NDHpple(xmlData: xml)
+
+        let testSuitesElem = try XCTUnwrap(parser.peekAtSearch(withQuery: "/*"))
+        XCTAssertEqual(testSuitesElem.rawValueOfAttribute(name: "name"), "JUnitReportName&lt;\'&amp;\\&gt;")
+
+        let testSuiteElem = try XCTUnwrap(testSuitesElem.firstChild(forName: "testsuite"))
+        XCTAssertEqual(testSuiteElem.rawValueOfAttribute(name: "name"), "JUnitReportTestSuiteName&lt;\'&amp;\\&gt;")
+        XCTAssertEqual(testSuiteElem.rawValueOfAttribute(name: "tests"), "1")
+
+        let testCaseElem = try XCTUnwrap(testSuiteElem.firstChild(forName: "testcase"))
+        XCTAssertEqual(testCaseElem.rawValueOfAttribute(name: "classname"), "MyClassName&lt;\'&amp;\\&gt;")
+        XCTAssertEqual(testCaseElem.rawValueOfAttribute(name: "name"), "MyName&lt;\'&amp;\\&gt;")
+        XCTAssertEqual(testCaseElem.rawValueOfAttribute(name: "time"), "0.00") // This needs a fix. Precision is lost not only here but in various places where numbers are used. #177
+
+        let systemOutElem = try XCTUnwrap(testCaseElem.firstChild(forName: "system-out"))
+        let systemOutContent = try XCTUnwrap(systemOutElem.children.first)
+        XCTAssertEqual(systemOutContent["rawValue"] as? String, "TitleHere&lt;\'&amp;\\&gt;")
+
+        let failureElem = try XCTUnwrap(testCaseElem.firstChild(forName: "failure"))
+        XCTAssertEqual(failureElem.rawValueOfAttribute(name: "message"), "Assertion Failure: &lt;unknown&gt;:0: Application com.example.test is not running")
+    }
+
+    static var allTests = [
+        ("testBasicFunctionality", testBasicFunctionality),
+    ]
+}

--- a/Tests/XCTestHTMLReportTests/TestSupportNDHppleElement.swift
+++ b/Tests/XCTestHTMLReportTests/TestSupportNDHppleElement.swift
@@ -1,0 +1,16 @@
+//
+//  TestSupportNDHppleElement.swift
+//
+//
+//  Created by Guillermo Ignacio Enriquez Gutierrez on 2021/01/18.
+//
+
+import Foundation
+
+import NDHpple
+
+extension NDHppleElement {
+    func rawValueOfAttribute(name: String) -> String? {
+        return attributes[name]?["rawValue"] as? String
+    }
+}


### PR DESCRIPTION
- Adds escaping for classes, functions, suites, etc in JUnit Report xml.
- Adds unit tests to prevent regressions.
- This solves #186. 
- Added tests will also prevent #131 from happening in the future.