### PR TITLE
Add ".log" extension to log filename

### DIFF
--- a/Sources/XCTestHTMLReportCore/Classes/Models/ResultFile.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/ResultFile.swift
@@ -73,12 +73,13 @@ class ResultFile {
             Logger.warning("Can't get logss with id \(id)")
             return nil
         }
-        let url = self.url.appendingPathComponent(id)
+        let fileName = "\(id).log"
+        let url = self.url.appendingPathComponent(fileName)
         let fileManager = FileManager.default
         do {
             try? fileManager.removeItem(at: url)
             try logSection.emittedOutput?.write(to: url, atomically: true, encoding: .utf8)
-            return relativeUrl.appendingPathComponent(id)
+            return relativeUrl.appendingPathComponent(fileName)
         } catch {
             Logger.warning("Can't write output to \(url). \(error.localizedDescription)")
             return nil


### PR DESCRIPTION
Fix for #147, #173 , potentially #145 .
Using "Resource Root URL" on Jenkins, so no CSP changes needed

edit: changed commit