### PR TITLE
Fix broken image link when using d option to merged xcresult by xcrun

### DIFF
--- a/Sources/XCTestHTMLReportCore/Classes/Helpers/UnattachedFiles.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Helpers/UnattachedFiles.swift
@@ -11,7 +11,7 @@ func removeUnattachedFiles(runs: [Run]) -> Int {
 
     var attachmentPathsLastItem: [String?] = []
     for run in runs {
-        attachmentPathsLastItem = run.allAttachments.map { $0.source?.lastPathComponent() }
+        attachmentPathsLastItem = attachmentPathsLastItem + run.allAttachments.map { $0.source?.lastPathComponent() }
         if case RenderingContent.url(let url) = run.logContent {
             attachmentPathsLastItem.append(url.lastPathComponent)
         }
@@ -27,7 +27,6 @@ func removeUnattachedFiles(runs: [Run]) -> Int {
         let lastPathComponent = fileURL.lastPathComponent
 
         if attachmentPathsLastItem.contains(lastPathComponent) {
-            Logger.success("don't remove this file!!")
             return false
         }
 

--- a/Sources/XCTestHTMLReportCore/Classes/Helpers/UnattachedFiles.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Helpers/UnattachedFiles.swift
@@ -9,13 +9,13 @@ func removeUnattachedFiles(runs: [Run]) -> Int {
     let fileManager = FileManager.default
     var removedFiles = 0
 
-    var attachmentPathsLastItem: [String?] = []
-    for run in runs {
-        attachmentPathsLastItem = attachmentPathsLastItem + run.allAttachments.map { $0.source?.lastPathComponent() }
+    let attachmentPathsLastItem = runs.map { run -> [String?] in
+        var lastPathComponents = run.allAttachments.map { $0.source?.lastPathComponent() }
         if case RenderingContent.url(let url) = run.logContent {
-            attachmentPathsLastItem.append(url.lastPathComponent)
+            lastPathComponents.append(url.lastPathComponent)
         }
-    }
+        return lastPathComponents
+    }.reduce([], +)
 
     func shouldBeDeleted(fileURL: URL) -> Bool {
         /// Do not delete directories
@@ -38,13 +38,11 @@ func removeUnattachedFiles(runs: [Run]) -> Int {
     }
 
     func searchFileURLs() throws -> [URL] {
-        var urls: [URL] = []
-        for run in runs {
+        return try runs.map { run -> [URL] in
             let topContents = try fileManager.contentsOfDirectory(at: run.file.url, includingPropertiesForKeys: nil)
             let dataContents = try fileManager.contentsOfDirectory(at: run.file.url.appendingPathComponent("Data"), includingPropertiesForKeys: nil)
-            urls = urls + topContents + dataContents
-        }
-        return urls
+            return topContents + dataContents
+        }.reduce([], +)
     }
 
     do {

--- a/Sources/XCTestHTMLReportCore/Classes/Helpers/UnattachedFiles.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Helpers/UnattachedFiles.swift
@@ -9,13 +9,13 @@ func removeUnattachedFiles(runs: [Run]) -> Int {
     let fileManager = FileManager.default
     var removedFiles = 0
 
-    let attachmentPathsLastItem = runs.map { run -> [String?] in
-        var lastPathComponents = run.allAttachments.map { $0.source?.lastPathComponent() }
+    var attachmentPathsLastItem: [String?] = []
+    for run in runs {
+        attachmentPathsLastItem = attachmentPathsLastItem + run.allAttachments.map { $0.source?.lastPathComponent() }
         if case RenderingContent.url(let url) = run.logContent {
-            lastPathComponents.append(url.lastPathComponent)
+            attachmentPathsLastItem.append(url.lastPathComponent)
         }
-        return lastPathComponents
-    }.reduce([], +)
+    }
 
     func shouldBeDeleted(fileURL: URL) -> Bool {
         /// Do not delete directories
@@ -38,11 +38,13 @@ func removeUnattachedFiles(runs: [Run]) -> Int {
     }
 
     func searchFileURLs() throws -> [URL] {
-        return try runs.map { run -> [URL] in
+        var urls: [URL] = []
+        for run in runs {
             let topContents = try fileManager.contentsOfDirectory(at: run.file.url, includingPropertiesForKeys: nil)
             let dataContents = try fileManager.contentsOfDirectory(at: run.file.url.appendingPathComponent("Data"), includingPropertiesForKeys: nil)
-            return topContents + dataContents
-        }.reduce([], +)
+            urls = urls + topContents + dataContents
+        }
+        return urls
     }
 
     do {

--- a/Sources/XCTestHTMLReportCore/Classes/Helpers/UnattachedFiles.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Helpers/UnattachedFiles.swift
@@ -4,13 +4,17 @@
 
 import Foundation
 
-func removeUnattachedFiles(run: Run) -> Int {
+func removeUnattachedFiles(runs: [Run]) -> Int {
     let skippedFiles = ["report.junit"]
     let fileManager = FileManager.default
     var removedFiles = 0
-    var attachmentPathsLastItem = run.allAttachments.map { $0.source?.lastPathComponent() }
-    if case RenderingContent.url(let url) = run.logContent {
-        attachmentPathsLastItem.append(url.lastPathComponent)
+
+    var attachmentPathsLastItem: [String?] = []
+    for run in runs {
+        attachmentPathsLastItem = run.allAttachments.map { $0.source?.lastPathComponent() }
+        if case RenderingContent.url(let url) = run.logContent {
+            attachmentPathsLastItem.append(url.lastPathComponent)
+        }
     }
 
     func shouldBeDeleted(fileURL: URL) -> Bool {
@@ -23,6 +27,7 @@ func removeUnattachedFiles(run: Run) -> Int {
         let lastPathComponent = fileURL.lastPathComponent
 
         if attachmentPathsLastItem.contains(lastPathComponent) {
+            Logger.success("don't remove this file!!")
             return false
         }
 
@@ -34,9 +39,13 @@ func removeUnattachedFiles(run: Run) -> Int {
     }
 
     func searchFileURLs() throws -> [URL] {
-        let topContents = try fileManager.contentsOfDirectory(at: run.file.url, includingPropertiesForKeys: nil)
-        let dataContents = try fileManager.contentsOfDirectory(at: run.file.url.appendingPathComponent("Data"), includingPropertiesForKeys: nil)
-        return topContents + dataContents
+        var urls: [URL] = []
+        for run in runs {
+            let topContents = try fileManager.contentsOfDirectory(at: run.file.url, includingPropertiesForKeys: nil)
+            let dataContents = try fileManager.contentsOfDirectory(at: run.file.url.appendingPathComponent("Data"), includingPropertiesForKeys: nil)
+            urls = urls + topContents + dataContents
+        }
+        return urls
     }
 
     do {

--- a/Sources/XCTestHTMLReportCore/Classes/Models/Summary.swift
+++ b/Sources/XCTestHTMLReportCore/Classes/Models/Summary.swift
@@ -67,9 +67,7 @@ public struct Summary
     public func deleteUnattachedFiles() {
         Logger.substep("Deleting unattached files..")
         var deletedFilesCount = 0
-        for run in runs {
-            deletedFilesCount += removeUnattachedFiles(run: run)
-        }
+        deletedFilesCount = removeUnattachedFiles(runs: runs)
         Logger.substep("Deleted \(deletedFilesCount) unattached files")
     }
 }


### PR DESCRIPTION
# Why
If there are multiple Runs, `attachmentPathsLastItem` does not contain the required filename.
Therefore, the image link will be broken with the d option.
Accepts multiple Runs and prevents necessary files from being deleted.

# What I did 

removeUnattachedFiles became to need a multiple Runs. 

# related issue
https://github.com/TitouanVanBelle/XCTestHTMLReport/issues/203